### PR TITLE
Add color mode selection system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,16 @@ The format is based on [Keep a Changelog], and this project adheres to [Break Ve
 
 ## [Unreleased]
 
+### Added
+
+* [#3](https://github.com/aaronmallen/sai/pull/3) - mode selection via `Sai::ModeSelector`
+  [@aaronmallen](https://github.com/aaronmallen)
+
 ### Changed
 
 * [#2](https://github.com/aaronmallen/sai/pull/2) - Immutable method chaining for `Sai::Decorator` by
+  [@aaronmallen](https://github.com/aaronmallen)
+* [#3](https://github.com/aaronmallen/sai/pull/3) - `Sia::Support` from class to module for improved API design
   [@aaronmallen](https://github.com/aaronmallen)
 
 ## 0.1.0 - 2025-01-19

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ You can check the terminal's capabilities:
 ```ruby
 # Using directly
 Sai.support.true_color? # => true/false
-Sai.support.bit8?      # => true/false
+Sai.support.advanced?      # => true/false
 Sai.support.ansi?      # => true/false
 Sai.support.basic?     # => true/false
 Sai.support.color?     # => true/false

--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ puts Sai.red.bold.italic.decorate('Error!')
 
 # Complex combinations
 puts Sai.bright_cyan
-       .on_blue
-       .bold
-       .italic
-       .decorate('Styled text')
+        .on_blue
+        .bold
+        .italic
+        .decorate('Styled text')
 ```
 
 ### Module Inclusion
@@ -94,7 +94,7 @@ class CLI
   end
 
   def success(message)
-    puts decorator.green.decorate(message)
+    puts decorator.with_mode(color_mode.ansi_auto).green.decorate(message)
   end
 end
 
@@ -235,6 +235,39 @@ Sai automatically detects your terminal's color capabilities and adapts the outp
 > [!NOTE]
 > This automatic downgrading ensures your application looks great across all terminal types without any extra code!
 
+### Color Mode Selection
+
+Sai provides flexible color mode selection through its `mode` interface:
+
+```ruby
+# Use automatic mode detection (default)
+Sai.with_mode(Sai.mode.auto)
+
+# Force specific color modes
+puts Sai.with_mode(Sai.mode.true_color).red.decorate('24-bit color')
+puts Sai.with_mode(Sai.mode.advanced).red.decorate('256 colors')
+puts Sai.with_mode(Sai.mode.ansi).red.decorate('16 colors')
+puts Sai.with_mode(Sai.mode.basic).red.decorate('8 colors')
+puts Sai.with_mode(Sai.mode.no_color).red.decorate('No color')
+
+# Use automatic downgrading
+puts Sai.with_mode(Sai.mode.advanced_auto).red.decorate('256 colors or less')
+puts Sai.with_mode(Sai.mode.ansi_auto).red.decorate('16 colors or less')
+puts Sai.with_mode(Sai.mode.basic_auto).red.decorate('8 colors or less')
+```
+
+> [!WARNING]
+> When using fixed color modes (like `true_color` or `advanced`), Sai will not automatically downgrade colors for
+> terminals with lower color support. For automatic color mode adjustment, use modes ending in `_auto`
+> (like `advanced_auto` or `ansi_auto`).
+
+This allows you to:
+
+* Explicitly set specific color modes
+* Use automatic mode detection (default)
+* Set maximum color modes with automatic downgrading
+* Disable colors entirely
+
 ### Terminal Support Detection
 
 You can check the terminal's capabilities:
@@ -242,7 +275,7 @@ You can check the terminal's capabilities:
 ```ruby
 # Using directly
 Sai.support.true_color? # => true/false
-Sai.support.advanced?      # => true/false
+Sai.support.advanced?   # => true/false
 Sai.support.ansi?      # => true/false
 Sai.support.basic?     # => true/false
 Sai.support.color?     # => true/false

--- a/lib/sai.rb
+++ b/lib/sai.rb
@@ -142,6 +142,26 @@ module Sai
     end
   end
 
+  # A helper method that provides Sai color modes
+  #
+  # @author {https://aaronmallen.me Aaron Allen}
+  # @since unreleased
+  #
+  # @api public
+  #
+  # @example
+  #   class MyClass
+  #     include Sai
+  #   end
+  #
+  #   MyClass.new.color_mode.ansi #=> 2
+  #
+  # @return [ModeSelector] the mode selector
+  # @rbs () -> singleton(ModeSelector)
+  def color_mode
+    ModeSelector
+  end
+
   # A helper method to initialize an instance of {Decorator}
   #
   # @author {https://aaronmallen.me Aaron Allen}

--- a/lib/sai.rb
+++ b/lib/sai.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
+require 'sai/conversion/color_sequence'
+require 'sai/conversion/rgb'
 require 'sai/decorator'
 require 'sai/mode_selector'
 require 'sai/support'
 require 'sai/terminal/capabilities'
-require 'singleton'
+require 'sai/terminal/color_mode'
 
 # An elegant color management system for crafting sophisticated CLI applications
 #
@@ -134,9 +136,9 @@ module Sai
     #   Sai.support.true_color? # => true
     #
     # @return [Support] the color support
-    # @rbs () -> Support
+    # @rbs () -> singleton(Support)
     def support
-      @support ||= Support.new(color_mode).freeze
+      Support
     end
 
     private
@@ -195,8 +197,8 @@ module Sai
   #   MyClass.new.terminal_color_support.true_color? # => true
   #
   # @return [Support] the color support
-  # @rbs () -> Support
+  # @rbs () -> singleton(Support)
   def terminal_color_support
-    Sai.support
+    Support
   end
 end

--- a/lib/sai.rb
+++ b/lib/sai.rb
@@ -112,7 +112,7 @@ module Sai
     # @example Check the color support of the terminal
     #   Sai.support.ansi? # => true
     #   Sai.support.basic? # => true
-    #   Sai.support.bit8? # => true
+    #   Sai.support.advanced? # => true
     #   Sai.support.no_color? # => false
     #   Sai.support.true_color? # => true
     #
@@ -173,7 +173,7 @@ module Sai
   #
   #   MyClass.new.terminal_color_support.ansi? # => true
   #   MyClass.new.terminal_color_support.basic? # => true
-  #   MyClass.new.terminal_color_support.bit8? # => true
+  #   MyClass.new.terminal_color_support.advanced? # => true
   #   MyClass.new.terminal_color_support.no_color? # => false
   #   MyClass.new.terminal_color_support.true_color? # => true
   #

--- a/lib/sai.rb
+++ b/lib/sai.rb
@@ -51,7 +51,7 @@ module Sai
     ignored_decorator_methods = %i[apply call decorate encode]
     Decorator.instance_methods(false).reject { |m| ignored_decorator_methods.include?(m) }.each do |method|
       define_method(method) do |*arguments, **keyword_arguments|
-        Decorator.new(send(:color_mode)).public_send(method, *arguments, **keyword_arguments)
+        Decorator.new(mode: Sai.mode.auto).public_send(method, *arguments, **keyword_arguments)
       end
     end
 
@@ -140,21 +140,6 @@ module Sai
     def support
       Support
     end
-
-    private
-
-    # Detect the color capabilities of the terminal
-    #
-    # @author {https://aaronmallen.me Aaron Allen}
-    # @since 0.1.0
-    #
-    # @api private
-    #
-    # @return [Integer] the color mode
-    # @rbs () -> Integer
-    def color_mode
-      Thread.current[:sai_color_mode] ||= Terminal::Capabilities.detect_color_support
-    end
   end
 
   # A helper method to initialize an instance of {Decorator}
@@ -172,10 +157,15 @@ module Sai
   #   MyClass.new.decorator.blue.on_red.bold.decorate('Hello, world!')
   #   #=> "\e[38;5;21m\e[48;5;160m\e[1mHello, world!\e[0m"
   #
+  #   MyClass.new.decorator(mode: Sai.mode.no_color)
+  #   #=> "Hello, world!"
+  #
+  # @param mode [Integer] the color mode to use
+  #
   # @return [Decorator] the Decorator instance
-  # @rbs () -> Decorator
-  def decorator
-    Decorator.new(Terminal::Capabilities.detect_color_support)
+  # @rbs (?mode: Integer) -> Decorator
+  def decorator(mode: Sai.mode.auto)
+    Decorator.new(mode:)
   end
 
   # The supported color modes for the terminal

--- a/lib/sai.rb
+++ b/lib/sai.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'sai/decorator'
+require 'sai/mode_selector'
 require 'sai/support'
 require 'sai/terminal/capabilities'
 require 'singleton'
@@ -50,6 +51,22 @@ module Sai
       define_method(method) do |*arguments, **keyword_arguments|
         Decorator.new(send(:color_mode)).public_send(method, *arguments, **keyword_arguments)
       end
+    end
+
+    # The Sai {ModeSelector mode selector}
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api public
+    #
+    # @example
+    #   Sai.mode.auto #=> 4
+    #
+    # @return [ModeSelector] the mode selector
+    # @rbs () -> singleton(ModeSelector)
+    def mode
+      ModeSelector
     end
 
     # @rbs!

--- a/lib/sai/conversion/color_sequence.rb
+++ b/lib/sai/conversion/color_sequence.rb
@@ -36,7 +36,7 @@ module Sai
 
           case mode
           when Terminal::ColorMode::TRUE_COLOR then true_color(rgb, style_type)
-          when Terminal::ColorMode::BIT8 then bit8(rgb, style_type)
+          when Terminal::ColorMode::ADVANCED then advanced(rgb, style_type)
           when Terminal::ColorMode::ANSI then ansi(rgb, style_type)
           when Terminal::ColorMode::BASIC then basic(rgb, style_type)
           else
@@ -45,6 +45,29 @@ module Sai
         end
 
         private
+
+        # Convert RGB values to an 8-bit color sequence
+        #
+        # @author {https://aaronmallen.me Aaron Allen}
+        # @since 0.1.0
+        #
+        # @api private
+        #
+        # @param rgb [Array<Integer>] the RGB components
+        # @param style_type [Symbol] the type of color (foreground or background)
+        #
+        # @return [String] the ANSI escape sequence
+        # @rbs (Array[Integer] rgb, style_type type) -> String
+        def advanced(rgb, style_type)
+          code = style_type == :background ? 48 : 38
+          color_code = if rgb.uniq.size == 1
+                         RGB.to_grayscale_index(rgb)
+                       else
+                         RGB.to_color_cube_index(rgb)
+                       end
+
+          "\e[#{code};5;#{color_code}m"
+        end
 
         # Convert RGB values to a 4-bit ANSI color sequence
         #
@@ -102,29 +125,6 @@ module Sai
           color = RGB.closest_ansi_color(r, g, b)
           code = base_color_for_style_type(ANSI::COLOR_CODES[color], style_type)
           "\e[#{code}m"
-        end
-
-        # Convert RGB values to an 8-bit color sequence
-        #
-        # @author {https://aaronmallen.me Aaron Allen}
-        # @since 0.1.0
-        #
-        # @api private
-        #
-        # @param rgb [Array<Integer>] the RGB components
-        # @param style_type [Symbol] the type of color (foreground or background)
-        #
-        # @return [String] the ANSI escape sequence
-        # @rbs (Array[Integer] rgb, style_type type) -> String
-        def bit8(rgb, style_type)
-          code = style_type == :background ? 48 : 38
-          color_code = if rgb.uniq.size == 1
-                         RGB.to_grayscale_index(rgb)
-                       else
-                         RGB.to_color_cube_index(rgb)
-                       end
-
-          "\e[#{code};5;#{color_code}m"
         end
 
         # Convert RGB values to a true color (24-bit) sequence

--- a/lib/sai/decorator.rb
+++ b/lib/sai/decorator.rb
@@ -801,6 +801,24 @@ module Sai
       dup.tap { |duped| duped.instance_variable_set(:@foreground, [red, green, blue]) }
     end
 
+    # Apply a specific color mode to the decorator
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api public
+    #
+    # @example
+    #   decorator.with_mode(Sai.mode.basic_auto) #=> => #<Sai::Decorator:0x123 @mode=1>
+    #
+    # @param mode [Integer] the color mode to use
+    #
+    # @return [Decorator] a new instance of Decorator with the applied color mode
+    # @rbs (Integer mode) -> Decorator
+    def with_mode(mode)
+      dup.tap { |duped| duped.instance_variable_set(:@mode, mode) }
+    end
+
     private
 
     # Apply a named color to the specified style type

--- a/lib/sai/mode_selector.rb
+++ b/lib/sai/mode_selector.rb
@@ -1,0 +1,298 @@
+# frozen_string_literal: true
+
+require 'sai/terminal/capabilities'
+require 'sai/terminal/color_mode'
+
+module Sai
+  # Color mode selection methods
+  #
+  # @author {https://aaronmallen.me Aaron Allen}
+  # @since unreleased
+  #
+  # @api public
+  module ModeSelector
+    class << self
+      # Set the color mode to 256 color (8-bit) mode
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @example
+      #   Sai.mode.advanced  #=> 3
+      #   Sai.mode.eight_bit #=> 3
+      #   Sai.mode.color256  #=> 3
+      #
+      # @return [Integer] the color mode
+      # @rbs () -> Integer
+      def advanced
+        Terminal::ColorMode::ADVANCED
+      end
+      alias color256 advanced
+      alias colour256 advanced
+      alias eight_bit advanced
+      alias two_hundred_fifty_six_color advanced
+      alias two_hundred_fifty_six_colour advanced
+
+      # Automatically set the color mode to advanced (8-bit) or lower
+      #
+      # Sets the terminal color mode to advanced (8-bit) support, which provides 256 colors
+      # The mode will automatically downgrade to 4-bit, 3-bit, or NO_COLOR if the terminal doesn't support
+      # advanced colors
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api public
+      #
+      # @example With color support enabled
+      #   ENV['COLORTERM']       #=> nil
+      #   ENV['TERM']            #=> 'xterm-256color'
+      #   Sai.mode.ansi_auto     #=> 3
+      #   Sai.mode.four_bit_auto #=> 3
+      #   Sai.mode.color_16_auto #=> 3
+      #
+      # @example With only 4-bit color support
+      #   ENV['NO_COLOR']        #=> nil
+      #   ENV['TERM']            #=> 'ansi'
+      #   Sai.mode.ansi_auto     #=> 2
+      #   Sai.mode.four_bit_auto #=> 2
+      #   Sai.mode.color_16_auto #=> 2
+      #
+      # @example With only 3-bit color support
+      #   ENV['TERM']             #=> nil
+      #   ENV['NO_COLOR']         #=> nil
+      #   Sai.mode.ansi_auto      #=> 1
+      #   Sai.mode.four_bit_auto  #=> 1
+      #   Sai.mode.color16_auto   #=> 1
+      #
+      # @example With color support disabled
+      #   ENV['NO_COLOR']         #=> 'true'
+      #   Sai.mode.ansi_auto      #=> 0
+      #   Sai.mode.four_bit_auto  #=> 0
+      #   Sai.mode.color16_auto   #=> 0
+      #
+      # @return [Integer] the color mode
+      # @rbs () -> Integer
+      def advanced_auto
+        [Terminal::Capabilities.detect_color_support, Terminal::ColorMode::ADVANCED].min
+      end
+      alias color256_auto advanced_auto
+      alias colour256_auto advanced_auto
+      alias eight_bit_auto advanced_auto
+      alias two_hundred_fifty_six_color_auto advanced_auto
+      alias two_hundred_fifty_six_colour_auto advanced_auto
+
+      # Set the color mode to 16 color (4-bit) mode
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api public
+      #
+      # @example
+      #   Sai.mode.ansi     #=> 2
+      #   Sai.mode.color16 #=> 2
+      #   Sai.mode.four_bit #=> 2
+      #
+      # @return [Integer] the color mode
+      # @rbs () -> Integer
+      def ansi
+        Terminal::ColorMode::ANSI
+      end
+      alias color16 ansi
+      alias colour16 ansi
+      alias four_bit ansi
+      alias sixteen_color ansi
+      alias sixteen_colour ansi
+
+      # Automatically set the color mode to ansi (4-bit) or lower
+      #
+      # Sets the terminal color mode to ansi (4-bit) support, which provides 8 colors
+      # The mode will automatically downgrade to 3-bit or NO_COLOR if the terminal doesn't support
+      # ansi colors
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api public
+      #
+      # @example With color support enabled
+      #   ENV['NO_COLOR'] #=> nil
+      #   ENV['TERM'] #=> 'ansi'
+      #   Sai.mode.ansi_auto     #=> 2
+      #   Sai.mode.four_bit_auto #=> 2
+      #   Sai.mode.color_16_auto #=> 2
+      #
+      # @example With only 3-bit color support
+      #   ENV['TERM']             #=> nil
+      #   ENV['NO_COLOR']         #=> nil
+      #   Sai.mode.ansi_auto      #=> 1
+      #   Sai.mode.four_bit_auto  #=> 1
+      #   Sai.mode.color16_auto   #=> 1
+      #
+      # @example With color support disabled
+      #   ENV['NO_COLOR']         #=> 'true'
+      #   Sai.mode.ansi_auto      #=> 0
+      #   Sai.mode.four_bit_auto  #=> 0
+      #   Sai.mode.color16_auto   #=> 0
+      #
+      # @return [Integer] the color mode
+      # @rbs () -> Integer
+      def ansi_auto
+        [Terminal::Capabilities.detect_color_support, Terminal::ColorMode::ANSI].min
+      end
+      alias color16_auto ansi_auto
+      alias colour16_auto ansi_auto
+      alias four_bit_auto ansi_auto
+      alias sixteen_color_auto ansi_auto
+      alias sixteen_colour_auto ansi_auto
+
+      # Set the color mode based on the current Terminal's capabilities
+      #
+      # This is the default color mode for {Sai}
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api public
+      #
+      # @example With 24-bit color support enabled
+      #   ENV['COLORTERM'] #=> 'truecolor'
+      #   Sai.node.auto    #=> 4
+      #
+      # @example With only 8-bit color support enabled
+      #   ENV['COLORTERM'] #=> nil
+      #   ENV['TERM']      #=> 'xterm-256color'
+      #   Sai.mode.auto    #=> 3
+      #
+      # @example With only 4-bit color support
+      #   ENV['NO_COLOR'] #=> nil
+      #   ENV['TERM']     #=> 'ansi'
+      #   Sai.mode.auto   #=> 2
+      #
+      # @example With only 3-bit color support
+      #   ENV['TERM']     #=> nil
+      #   ENV['NO_COLOR'] #=> nil
+      #   Sai.mode.auto   #=> 1
+      #
+      # @example With color support disabled
+      #   ENV['NO_COLOR'] #=> 'true'
+      #   Sai.mode.auto   #=> 0
+      #
+      # @return [Integer] the color mode
+      # @rbs () -> Integer
+      def auto
+        Terminal::Capabilities.detect_color_support
+      end
+      alias color16m_auto auto
+      alias colour16m_auto auto
+      alias enabled auto
+      alias sixteen_million_color_auto auto
+      alias sixteen_million_colour_auto auto
+      alias twenty_for_bit_auto auto
+
+      # Set the color mode to 8 color (3-bit) mode
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api public
+      #
+      # @example
+      #   Sai.mode.basic     #=> 1
+      #   Sai.mode.color8    #=> 1
+      #   Sai.mode.three_bit #=> 1
+      #
+      # @return [Integer] the 4 color (3-bit) mode
+      # @rbs () -> Integer
+      def basic
+        Terminal::ColorMode::BASIC
+      end
+      alias color8 basic
+      alias colour8 basic
+      alias eight_color basic
+      alias eight_colour basic
+      alias three_bit basic
+
+      # Automatically set the color mode to basic (3-bit) or lower
+      #
+      # Sets the terminal color mode to basic (3-bit) support, which provides 8 colors
+      # The mode will automatically downgrade to NO_COLOR if the terminal doesn't support
+      # basic colors
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api public
+      #
+      # @example With color support enabled
+      #   ENV['NO_COLOR']         #=> nil
+      #   Sai.mode.basic_auto     #=> 1
+      #   Sai.mode.three_bit_auto #=> 1
+      #   Sai.mode.color8_auto    #=> 1
+      #
+      # @example With color support disabled
+      #   ENV['NO_COLOR']         #=> 'true'
+      #   Sai.mode.basic_auto     #=> 0
+      #   Sai.mode.three_bit_auto #=> 0
+      #   Sai.mode.color8_auto    #=> 0
+      #
+      # @return [Integer] the color mode
+      # @rbs () -> Integer
+      def basic_auto
+        [Terminal::Capabilities.detect_color_support, Terminal::ColorMode::BASIC].min
+      end
+      alias color8_auto basic_auto
+      alias colour8_auto basic_auto
+      alias eight_color_auto basic_auto
+      alias eight_colour_auto basic_auto
+      alias three_bit_auto basic_auto
+
+      # Set the color mode to disable all color and styling
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api public
+      #
+      # @example
+      #   Sai.mode.no_color #=> 0
+      #   Sai.mode.disabled #=> 0
+      #   Sai.mode.mono     #=> 0
+      #
+      # @return [Integer] the color mode
+      # @rbs () -> Integer
+      def no_color
+        Terminal::ColorMode::NO_COLOR
+      end
+      alias disabled no_color
+      alias mono no_color
+      alias no_colour no_color
+
+      # Set the color mode to 16-million color (24-bit) mode
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @example
+      #   Sai.mode.true_color      #=> 4
+      #   Sai.mode.twenty_four_bit #=> 4
+      #   Sai.mode.color_16m       #=> 4
+      #
+      # @return [Integer] the color mode
+      # @rbs () -> Integer
+      def true_color
+        Terminal::ColorMode::TRUE_COLOR
+      end
+      alias color16m true_color
+      alias colour16m true_color
+      alias sixteen_million_color true_color
+      alias sixteen_million_colour true_color
+      alias twenty_for_bit true_color
+    end
+  end
+end

--- a/lib/sai/support.rb
+++ b/lib/sai/support.rb
@@ -25,6 +25,23 @@ module Sai
       @color_mode = color_mode
     end
 
+    # Check if the terminal supports 256 colors (8-bit)
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since 0.1.0
+    #
+    # @api public
+    #
+    # @example Check if the terminal supports 256 colors
+    #   Sai.advanced? # => true
+    #
+    # @return [Boolean] `true` if the terminal supports 256 colors (8-bit), otherwise `false`
+    # @rbs () -> bool
+    def advanced?
+      @color_mode >= Terminal::ColorMode::ADVANCED
+    end
+    alias eight_bit? advanced?
+
     # Check if the terminal supports ANSI colors (4-bit)
     #
     # @author {https://aaronmallen.me Aaron Allen}
@@ -60,23 +77,6 @@ module Sai
     end
     alias bit3? basic?
     alias three_bit? basic?
-
-    # Check if the terminal supports 256 colors (8-bit)
-    #
-    # @author {https://aaronmallen.me Aaron Allen}
-    # @since 0.1.0
-    #
-    # @api public
-    #
-    # @example Check if the terminal supports 256 colors
-    #   Sai.bit8? # => true
-    #
-    # @return [Boolean] `true` if the terminal supports 256 colors (8-bit), otherwise `false`
-    # @rbs () -> bool
-    def bit8?
-      @color_mode >= Terminal::ColorMode::BIT8
-    end
-    alias eight_bit? bit8?
 
     # Check if the terminal supports color output
     #

--- a/lib/sai/support.rb
+++ b/lib/sai/support.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'sai/terminal/capabilities'
 require 'sai/terminal/color_mode'
 
 module Sai
@@ -9,107 +10,107 @@ module Sai
   # @since 0.1.0
   #
   # @api public
-  class Support
-    # Initialize a new instance of Support
-    #
-    # @author {https://aaronmallen.me Aaron Allen}
-    # @since 0.1.0
-    #
-    # @api private
-    #
-    # @param color_mode [Integer] the color mode
-    #
-    # @return [Support] the new instance of support
-    # @rbs (Integer color_mode) -> void
-    def initialize(color_mode)
-      @color_mode = color_mode
-    end
+  module Support
+    class << self
+      # Check if the terminal supports 256 colors (8-bit)
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since 0.1.0
+      #
+      # @api public
+      #
+      # @example Check if the terminal supports 256 colors
+      #   Sai.advanced? # => true
+      #
+      # @return [Boolean] `true` if the terminal supports 256 colors (8-bit), otherwise `false`
+      # @rbs () -> bool
+      def advanced?
+        Terminal::Capabilities.detect_color_support >= Terminal::ColorMode::ADVANCED
+      end
+      alias color256? advanced?
+      alias colour256? advanced?
+      alias eight_bit? advanced?
+      alias two_hundred_fifty_six_color? advanced?
+      alias two_hundred_fifty_six_colour? advanced?
 
-    # Check if the terminal supports 256 colors (8-bit)
-    #
-    # @author {https://aaronmallen.me Aaron Allen}
-    # @since 0.1.0
-    #
-    # @api public
-    #
-    # @example Check if the terminal supports 256 colors
-    #   Sai.advanced? # => true
-    #
-    # @return [Boolean] `true` if the terminal supports 256 colors (8-bit), otherwise `false`
-    # @rbs () -> bool
-    def advanced?
-      @color_mode >= Terminal::ColorMode::ADVANCED
-    end
-    alias eight_bit? advanced?
+      # Check if the terminal supports ANSI colors (4-bit)
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since 0.1.0
+      #
+      # @api public
+      #
+      # @example Check if the terminal supports ANSI colors
+      #   Sai.ansi? # => true
+      #
+      # @return [Boolean] `true` if the terminal supports ANSI colors (4-bit), otherwise `false`
+      # @rbs () -> bool
+      def ansi?
+        Terminal::Capabilities.detect_color_support >= Terminal::ColorMode::ANSI
+      end
+      alias color16? ansi?
+      alias colour16? ansi?
+      alias four_bit? ansi?
+      alias sixteen_color? ansi?
+      alias sixteen_colour? ansi?
 
-    # Check if the terminal supports ANSI colors (4-bit)
-    #
-    # @author {https://aaronmallen.me Aaron Allen}
-    # @since 0.1.0
-    #
-    # @api public
-    #
-    # @example Check if the terminal supports ANSI colors
-    #   Sai.ansi? # => true
-    #
-    # @return [Boolean] `true` if the terminal supports ANSI colors (4-bit), otherwise `false`
-    # @rbs () -> bool
-    def ansi?
-      @color_mode >= Terminal::ColorMode::ANSI
-    end
-    alias bit4? ansi?
-    alias four_bit? ansi?
+      # Check if the terminal supports basic colors (3-bit)
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since 0.1.0
+      #
+      # @api public
+      #
+      # @example Check if the terminal supports basic colors
+      #   Sai.basic? # => true
+      #
+      # @return [Boolean] `true` if the terminal supports basic colors (3-bit), otherwise `false`
+      # @rbs () -> bool
+      def basic?
+        Terminal::Capabilities.detect_color_support >= Terminal::ColorMode::BASIC
+      end
+      alias color8? basic?
+      alias colour8? basic?
+      alias eight_color? basic?
+      alias eight_colour? basic?
+      alias three_bit? basic?
 
-    # Check if the terminal supports basic colors (3-bit)
-    #
-    # @author {https://aaronmallen.me Aaron Allen}
-    # @since 0.1.0
-    #
-    # @api public
-    #
-    # @example Check if the terminal supports basic colors
-    #   Sai.basic? # => true
-    #
-    # @return [Boolean] `true` if the terminal supports basic colors (3-bit), otherwise `false`
-    # @rbs () -> bool
-    def basic?
-      @color_mode >= Terminal::ColorMode::BASIC
-    end
-    alias bit3? basic?
-    alias three_bit? basic?
+      # Check if the terminal supports color output
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since 0.1.0
+      #
+      # @api public
+      #
+      # @example Check if the terminal supports color
+      #   Sai.color? # => true
+      #
+      # @return [Boolean] `true` if the terminal supports color output, otherwise `false`
+      # @rbs () -> bool
+      def color?
+        Terminal::Capabilities.detect_color_support > Terminal::ColorMode::NO_COLOR
+      end
 
-    # Check if the terminal supports color output
-    #
-    # @author {https://aaronmallen.me Aaron Allen}
-    # @since 0.1.0
-    #
-    # @api public
-    #
-    # @example Check if the terminal supports color
-    #   Sai.color? # => true
-    #
-    # @return [Boolean] `true` if the terminal supports color output, otherwise `false`
-    # @rbs () -> bool
-    def color?
-      @color_mode > Terminal::ColorMode::NO_COLOR
+      # Check if the terminal supports true color (24-bit)
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since 0.1.0
+      #
+      # @api public
+      #
+      # @example Check if the terminal supports true color
+      #   Sai.true_color? # => true
+      #
+      # @return [Boolean] `true` if the terminal supports true color (24-bit), otherwise `false`
+      # @rbs () -> bool
+      def true_color?
+        Terminal::Capabilities.detect_color_support >= Terminal::ColorMode::TRUE_COLOR
+      end
+      alias color16m? true_color?
+      alias colour16m? true_color?
+      alias sixteen_million_color? true_color?
+      alias sixteen_million_colour? true_color?
+      alias twenty_for_bit? true_color?
     end
-
-    # Check if the terminal supports true color (24-bit)
-    #
-    # @author {https://aaronmallen.me Aaron Allen}
-    # @since 0.1.0
-    #
-    # @api public
-    #
-    # @example Check if the terminal supports true color
-    #   Sai.true_color? # => true
-    #
-    # @return [Boolean] `true` if the terminal supports true color (24-bit), otherwise `false`
-    # @rbs () -> bool
-    def true_color?
-      @color_mode >= Terminal::ColorMode::TRUE_COLOR
-    end
-    alias bit24? true_color?
-    alias twenty_four_bit? true_color?
   end
 end

--- a/lib/sai/terminal/capabilities.rb
+++ b/lib/sai/terminal/capabilities.rb
@@ -24,7 +24,7 @@ module Sai
         def detect_color_support
           return ColorMode::NO_COLOR if no_color?
           return ColorMode::TRUE_COLOR if true_color?
-          return ColorMode::BIT8 if bit8?
+          return ColorMode::ADVANCED if advanced?
           return ColorMode::ANSI if ansi?
           return ColorMode::BASIC if basic?
 
@@ -32,6 +32,21 @@ module Sai
         end
 
         private
+
+        # Check for 256 color (8-bit) support
+        #
+        # @author {https://aaronmallen.me Aaron Allen}
+        # @since 0.1.0
+        #
+        # @api private
+        #
+        # @return [Boolean] `true` if the terminal supports 256 colors, otherwise `false`
+        # @rbs () -> bool
+        def advanced?
+          return true if ENV.fetch('TERM', '').end_with?('-256color')
+
+          ENV.fetch('COLORTERM', '0').to_i >= 256
+        end
 
         # Check for ANSI color support
         #
@@ -59,21 +74,6 @@ module Sai
         # @rbs () -> bool
         def basic?
           !ENV.fetch('TERM', '').empty?
-        end
-
-        # Check for 256 color (8-bit) support
-        #
-        # @author {https://aaronmallen.me Aaron Allen}
-        # @since 0.1.0
-        #
-        # @api private
-        #
-        # @return [Boolean] `true` if the terminal supports 256 colors, otherwise `false`
-        # @rbs () -> bool
-        def bit8?
-          return true if ENV.fetch('TERM', '').end_with?('-256color')
-
-          ENV.fetch('COLORTERM', '0').to_i >= 256
         end
 
         # Check for NO_COLOR environment variable

--- a/lib/sai/terminal/color_mode.rb
+++ b/lib/sai/terminal/color_mode.rb
@@ -47,7 +47,7 @@ module Sai
       # @api private
       #
       # @return [Integer] the color mode
-      BIT8 = 3 #: Integer
+      ADVANCED = 3 #: Integer
 
       # The terminal supports 16 million colors (24-bit)
       #

--- a/sig/sai.rbs
+++ b/sig/sai.rbs
@@ -39,6 +39,20 @@
 #
 #   Sai.support.true_color? # => true
 module Sai
+  # The Sai {ModeSelector mode selector}
+  #
+  # @author {https://aaronmallen.me Aaron Allen}
+  # @since unreleased
+  #
+  # @api public
+  #
+  # @example
+  #   Sai.mode.auto #=> 4
+  #
+  # @return [ModeSelector] the mode selector
+  # @rbs () -> singleton(ModeSelector)
+  def self.mode: () -> singleton(ModeSelector)
+
   def black: () -> Decorator
 
   def blink: () -> Decorator

--- a/sig/sai.rbs
+++ b/sig/sai.rbs
@@ -164,8 +164,8 @@ module Sai
   #   Sai.support.true_color? # => true
   #
   # @return [Support] the color support
-  # @rbs () -> Support
-  def self.support: () -> Support
+  # @rbs () -> singleton(Support)
+  def self.support: () -> singleton(Support)
 
   # Detect the color capabilities of the terminal
   #
@@ -216,6 +216,6 @@ module Sai
   #   MyClass.new.terminal_color_support.true_color? # => true
   #
   # @return [Support] the color support
-  # @rbs () -> Support
-  def terminal_color_support: () -> Support
+  # @rbs () -> singleton(Support)
+  def terminal_color_support: () -> singleton(Support)
 end

--- a/sig/sai.rbs
+++ b/sig/sai.rbs
@@ -167,6 +167,24 @@ module Sai
   # @rbs () -> singleton(Support)
   def self.support: () -> singleton(Support)
 
+  # A helper method that provides Sai color modes
+  #
+  # @author {https://aaronmallen.me Aaron Allen}
+  # @since unreleased
+  #
+  # @api public
+  #
+  # @example
+  #   class MyClass
+  #     include Sai
+  #   end
+  #
+  #   MyClass.new.color_mode.ansi #=> 2
+  #
+  # @return [ModeSelector] the mode selector
+  # @rbs () -> singleton(ModeSelector)
+  def color_mode: () -> singleton(ModeSelector)
+
   # A helper method to initialize an instance of {Decorator}
   #
   # @author {https://aaronmallen.me Aaron Allen}

--- a/sig/sai.rbs
+++ b/sig/sai.rbs
@@ -145,7 +145,7 @@ module Sai
   # @example Check the color support of the terminal
   #   Sai.support.ansi? # => true
   #   Sai.support.basic? # => true
-  #   Sai.support.bit8? # => true
+  #   Sai.support.advanced? # => true
   #   Sai.support.no_color? # => false
   #   Sai.support.true_color? # => true
   #
@@ -197,7 +197,7 @@ module Sai
   #
   #   MyClass.new.terminal_color_support.ansi? # => true
   #   MyClass.new.terminal_color_support.basic? # => true
-  #   MyClass.new.terminal_color_support.bit8? # => true
+  #   MyClass.new.terminal_color_support.advanced? # => true
   #   MyClass.new.terminal_color_support.no_color? # => false
   #   MyClass.new.terminal_color_support.true_color? # => true
   #

--- a/sig/sai.rbs
+++ b/sig/sai.rbs
@@ -167,17 +167,6 @@ module Sai
   # @rbs () -> singleton(Support)
   def self.support: () -> singleton(Support)
 
-  # Detect the color capabilities of the terminal
-  #
-  # @author {https://aaronmallen.me Aaron Allen}
-  # @since 0.1.0
-  #
-  # @api private
-  #
-  # @return [Integer] the color mode
-  # @rbs () -> Integer
-  private def self.color_mode: () -> Integer
-
   # A helper method to initialize an instance of {Decorator}
   #
   # @author {https://aaronmallen.me Aaron Allen}
@@ -193,9 +182,14 @@ module Sai
   #   MyClass.new.decorator.blue.on_red.bold.decorate('Hello, world!')
   #   #=> "\e[38;5;21m\e[48;5;160m\e[1mHello, world!\e[0m"
   #
+  #   MyClass.new.decorator(mode: Sai.mode.no_color)
+  #   #=> "Hello, world!"
+  #
+  # @param mode [Integer] the color mode to use
+  #
   # @return [Decorator] the Decorator instance
-  # @rbs () -> Decorator
-  def decorator: () -> Decorator
+  # @rbs (?mode: Integer) -> Decorator
+  def decorator: (?mode: Integer) -> Decorator
 
   # The supported color modes for the terminal
   #

--- a/sig/sai/conversion/color_sequence.rbs
+++ b/sig/sai/conversion/color_sequence.rbs
@@ -26,6 +26,20 @@ module Sai
       # @rbs (Array[Integer] | String | Symbol color, Integer mode, ?style_type style_type) -> String
       def self.resolve: (Array[Integer] | String | Symbol color, Integer mode, ?style_type style_type) -> String
 
+      # Convert RGB values to an 8-bit color sequence
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since 0.1.0
+      #
+      # @api private
+      #
+      # @param rgb [Array<Integer>] the RGB components
+      # @param style_type [Symbol] the type of color (foreground or background)
+      #
+      # @return [String] the ANSI escape sequence
+      # @rbs (Array[Integer] rgb, style_type type) -> String
+      private def self.advanced: (Array[Integer] rgb, style_type type) -> String
+
       # Convert RGB values to a 4-bit ANSI color sequence
       #
       # @author {https://aaronmallen.me Aaron Allen}
@@ -67,20 +81,6 @@ module Sai
       # @return [String] the ANSI escape sequence
       # @rbs (Array[Integer] rgb, style_type style_type) -> String
       private def self.basic: (Array[Integer] rgb, style_type style_type) -> String
-
-      # Convert RGB values to an 8-bit color sequence
-      #
-      # @author {https://aaronmallen.me Aaron Allen}
-      # @since 0.1.0
-      #
-      # @api private
-      #
-      # @param rgb [Array<Integer>] the RGB components
-      # @param style_type [Symbol] the type of color (foreground or background)
-      #
-      # @return [String] the ANSI escape sequence
-      # @rbs (Array[Integer] rgb, style_type type) -> String
-      private def self.bit8: (Array[Integer] rgb, style_type type) -> String
 
       # Convert RGB values to a true color (24-bit) sequence
       #

--- a/sig/sai/decorator.rbs
+++ b/sig/sai/decorator.rbs
@@ -212,6 +212,22 @@ module Sai
     # @rbs (Integer red, Integer green, Integer blue) -> Decorator
     def rgb: (Integer red, Integer green, Integer blue) -> Decorator
 
+    # Apply a specific color mode to the decorator
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api public
+    #
+    # @example
+    #   decorator.with_mode(Sai.mode.basic_auto) #=> => #<Sai::Decorator:0x123 @mode=1>
+    #
+    # @param mode [Integer] the color mode to use
+    #
+    # @return [Decorator] a new instance of Decorator with the applied color mode
+    # @rbs (Integer mode) -> Decorator
+    def with_mode: (Integer mode) -> Decorator
+
     private
 
     # Apply a named color to the specified style type

--- a/sig/sai/decorator.rbs
+++ b/sig/sai/decorator.rbs
@@ -15,11 +15,11 @@ module Sai
     #
     # @api private
     #
-    # @param color_mode [Integer] the color mode to use
+    # @param mode [Integer] the color mode to use
     #
     # @return [Decorator] the new instance of Decorator
-    # @rbs (Integer color_mode) -> void
-    def initialize: (Integer color_mode) -> void
+    # @rbs (?mode: Integer) -> void
+    def initialize: (?mode: Integer) -> void
 
     def black: () -> Decorator
 
@@ -242,5 +242,16 @@ module Sai
     # @return [Decorator] a new instance of Decorator with the style applied
     # @rbs (String | Symbol style) -> self
     def apply_style: (String | Symbol style) -> self
+
+    # Check if text should be decorated
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api private
+    #
+    # @return [Boolean] `true` if text should be decorated, `false` otherwise
+    # @rbs () -> bool
+    def should_decorate?: () -> bool
   end
 end

--- a/sig/sai/mode_selector.rbs
+++ b/sig/sai/mode_selector.rbs
@@ -1,0 +1,319 @@
+# Generated from lib/sai/mode_selector.rb with RBS::Inline
+
+module Sai
+  # Color mode selection methods
+  #
+  # @author {https://aaronmallen.me Aaron Allen}
+  # @since unreleased
+  #
+  # @api public
+  module ModeSelector
+    # Set the color mode to 256 color (8-bit) mode
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api private
+    #
+    # @example
+    #   Sai.mode.advanced  #=> 3
+    #   Sai.mode.eight_bit #=> 3
+    #   Sai.mode.color256  #=> 3
+    #
+    # @return [Integer] the color mode
+    # @rbs () -> Integer
+    def self.advanced: () -> Integer
+
+    alias self.color256 self.advanced
+
+    alias self.colour256 self.advanced
+
+    alias self.eight_bit self.advanced
+
+    alias self.two_hundred_fifty_six_color self.advanced
+
+    alias self.two_hundred_fifty_six_colour self.advanced
+
+    # Automatically set the color mode to advanced (8-bit) or lower
+    #
+    # Sets the terminal color mode to advanced (8-bit) support, which provides 256 colors
+    # The mode will automatically downgrade to 4-bit, 3-bit, or NO_COLOR if the terminal doesn't support
+    # advanced colors
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api public
+    #
+    # @example With color support enabled
+    #   ENV['COLORTERM']       #=> nil
+    #   ENV['TERM']            #=> 'xterm-256color'
+    #   Sai.mode.ansi_auto     #=> 3
+    #   Sai.mode.four_bit_auto #=> 3
+    #   Sai.mode.color_16_auto #=> 3
+    #
+    # @example With only 4-bit color support
+    #   ENV['NO_COLOR']        #=> nil
+    #   ENV['TERM']            #=> 'ansi'
+    #   Sai.mode.ansi_auto     #=> 2
+    #   Sai.mode.four_bit_auto #=> 2
+    #   Sai.mode.color_16_auto #=> 2
+    #
+    # @example With only 3-bit color support
+    #   ENV['TERM']             #=> nil
+    #   ENV['NO_COLOR']         #=> nil
+    #   Sai.mode.ansi_auto      #=> 1
+    #   Sai.mode.four_bit_auto  #=> 1
+    #   Sai.mode.color16_auto   #=> 1
+    #
+    # @example With color support disabled
+    #   ENV['NO_COLOR']         #=> 'true'
+    #   Sai.mode.ansi_auto      #=> 0
+    #   Sai.mode.four_bit_auto  #=> 0
+    #   Sai.mode.color16_auto   #=> 0
+    #
+    # @return [Integer] the color mode
+    # @rbs () -> Integer
+    def self.advanced_auto: () -> Integer
+
+    alias self.color256_auto self.advanced_auto
+
+    alias self.colour256_auto self.advanced_auto
+
+    alias self.eight_bit_auto self.advanced_auto
+
+    alias self.two_hundred_fifty_six_color_auto self.advanced_auto
+
+    alias self.two_hundred_fifty_six_colour_auto self.advanced_auto
+
+    # Set the color mode to 16 color (4-bit) mode
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api public
+    #
+    # @example
+    #   Sai.mode.ansi     #=> 2
+    #   Sai.mode.color16 #=> 2
+    #   Sai.mode.four_bit #=> 2
+    #
+    # @return [Integer] the color mode
+    # @rbs () -> Integer
+    def self.ansi: () -> Integer
+
+    alias self.color16 self.ansi
+
+    alias self.colour16 self.ansi
+
+    alias self.four_bit self.ansi
+
+    alias self.sixteen_color self.ansi
+
+    alias self.sixteen_colour self.ansi
+
+    # Automatically set the color mode to ansi (4-bit) or lower
+    #
+    # Sets the terminal color mode to ansi (4-bit) support, which provides 8 colors
+    # The mode will automatically downgrade to 3-bit or NO_COLOR if the terminal doesn't support
+    # ansi colors
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api public
+    #
+    # @example With color support enabled
+    #   ENV['NO_COLOR'] #=> nil
+    #   ENV['TERM'] #=> 'ansi'
+    #   Sai.mode.ansi_auto     #=> 2
+    #   Sai.mode.four_bit_auto #=> 2
+    #   Sai.mode.color_16_auto #=> 2
+    #
+    # @example With only 3-bit color support
+    #   ENV['TERM']             #=> nil
+    #   ENV['NO_COLOR']         #=> nil
+    #   Sai.mode.ansi_auto      #=> 1
+    #   Sai.mode.four_bit_auto  #=> 1
+    #   Sai.mode.color16_auto   #=> 1
+    #
+    # @example With color support disabled
+    #   ENV['NO_COLOR']         #=> 'true'
+    #   Sai.mode.ansi_auto      #=> 0
+    #   Sai.mode.four_bit_auto  #=> 0
+    #   Sai.mode.color16_auto   #=> 0
+    #
+    # @return [Integer] the color mode
+    # @rbs () -> Integer
+    def self.ansi_auto: () -> Integer
+
+    alias self.color16_auto self.ansi_auto
+
+    alias self.colour16_auto self.ansi_auto
+
+    alias self.four_bit_auto self.ansi_auto
+
+    alias self.sixteen_color_auto self.ansi_auto
+
+    alias self.sixteen_colour_auto self.ansi_auto
+
+    # Set the color mode based on the current Terminal's capabilities
+    #
+    # This is the default color mode for {Sai}
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api public
+    #
+    # @example With 24-bit color support enabled
+    #   ENV['COLORTERM'] #=> 'truecolor'
+    #   Sai.node.auto    #=> 4
+    #
+    # @example With only 8-bit color support enabled
+    #   ENV['COLORTERM'] #=> nil
+    #   ENV['TERM']      #=> 'xterm-256color'
+    #   Sai.mode.auto    #=> 3
+    #
+    # @example With only 4-bit color support
+    #   ENV['NO_COLOR'] #=> nil
+    #   ENV['TERM']     #=> 'ansi'
+    #   Sai.mode.auto   #=> 2
+    #
+    # @example With only 3-bit color support
+    #   ENV['TERM']     #=> nil
+    #   ENV['NO_COLOR'] #=> nil
+    #   Sai.mode.auto   #=> 1
+    #
+    # @example With color support disabled
+    #   ENV['NO_COLOR'] #=> 'true'
+    #   Sai.mode.auto   #=> 0
+    #
+    # @return [Integer] the color mode
+    # @rbs () -> Integer
+    def self.auto: () -> Integer
+
+    alias self.color16m_auto self.auto
+
+    alias self.colour16m_auto self.auto
+
+    alias self.enabled self.auto
+
+    alias self.sixteen_million_color_auto self.auto
+
+    alias self.sixteen_million_colour_auto self.auto
+
+    alias self.twenty_for_bit_auto self.auto
+
+    # Set the color mode to 8 color (3-bit) mode
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api public
+    #
+    # @example
+    #   Sai.mode.basic     #=> 1
+    #   Sai.mode.color8    #=> 1
+    #   Sai.mode.three_bit #=> 1
+    #
+    # @return [Integer] the 4 color (3-bit) mode
+    # @rbs () -> Integer
+    def self.basic: () -> Integer
+
+    alias self.color8 self.basic
+
+    alias self.colour8 self.basic
+
+    alias self.eight_color self.basic
+
+    alias self.eight_colour self.basic
+
+    alias self.three_bit self.basic
+
+    # Automatically set the color mode to basic (3-bit) or lower
+    #
+    # Sets the terminal color mode to basic (3-bit) support, which provides 8 colors
+    # The mode will automatically downgrade to NO_COLOR if the terminal doesn't support
+    # basic colors
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api public
+    #
+    # @example With color support enabled
+    #   ENV['NO_COLOR']         #=> nil
+    #   Sai.mode.basic_auto     #=> 1
+    #   Sai.mode.three_bit_auto #=> 1
+    #   Sai.mode.color8_auto    #=> 1
+    #
+    # @example With color support disabled
+    #   ENV['NO_COLOR']         #=> 'true'
+    #   Sai.mode.basic_auto     #=> 0
+    #   Sai.mode.three_bit_auto #=> 0
+    #   Sai.mode.color8_auto    #=> 0
+    #
+    # @return [Integer] the color mode
+    # @rbs () -> Integer
+    def self.basic_auto: () -> Integer
+
+    alias self.color8_auto self.basic_auto
+
+    alias self.colour8_auto self.basic_auto
+
+    alias self.eight_color_auto self.basic_auto
+
+    alias self.eight_colour_auto self.basic_auto
+
+    alias self.three_bit_auto self.basic_auto
+
+    # Set the color mode to disable all color and styling
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api public
+    #
+    # @example
+    #   Sai.mode.no_color #=> 0
+    #   Sai.mode.disabled #=> 0
+    #   Sai.mode.mono     #=> 0
+    #
+    # @return [Integer] the color mode
+    # @rbs () -> Integer
+    def self.no_color: () -> Integer
+
+    alias self.disabled self.no_color
+
+    alias self.mono self.no_color
+
+    alias self.no_colour self.no_color
+
+    # Set the color mode to 16-million color (24-bit) mode
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api private
+    #
+    # @example
+    #   Sai.mode.true_color      #=> 4
+    #   Sai.mode.twenty_four_bit #=> 4
+    #   Sai.mode.color_16m       #=> 4
+    #
+    # @return [Integer] the color mode
+    # @rbs () -> Integer
+    def self.true_color: () -> Integer
+
+    alias self.color16m self.true_color
+
+    alias self.colour16m self.true_color
+
+    alias self.sixteen_million_color self.true_color
+
+    alias self.sixteen_million_colour self.true_color
+
+    alias self.twenty_for_bit self.true_color
+  end
+end

--- a/sig/sai/support.rbs
+++ b/sig/sai/support.rbs
@@ -7,20 +7,7 @@ module Sai
   # @since 0.1.0
   #
   # @api public
-  class Support
-    # Initialize a new instance of Support
-    #
-    # @author {https://aaronmallen.me Aaron Allen}
-    # @since 0.1.0
-    #
-    # @api private
-    #
-    # @param color_mode [Integer] the color mode
-    #
-    # @return [Support] the new instance of support
-    # @rbs (Integer color_mode) -> void
-    def initialize: (Integer color_mode) -> void
-
+  module Support
     # Check if the terminal supports 256 colors (8-bit)
     #
     # @author {https://aaronmallen.me Aaron Allen}
@@ -33,9 +20,17 @@ module Sai
     #
     # @return [Boolean] `true` if the terminal supports 256 colors (8-bit), otherwise `false`
     # @rbs () -> bool
-    def advanced?: () -> bool
+    def self.advanced?: () -> bool
 
-    alias eight_bit? advanced?
+    alias self.color256? self.advanced?
+
+    alias self.colour256? self.advanced?
+
+    alias self.eight_bit? self.advanced?
+
+    alias self.two_hundred_fifty_six_color? self.advanced?
+
+    alias self.two_hundred_fifty_six_colour? self.advanced?
 
     # Check if the terminal supports ANSI colors (4-bit)
     #
@@ -49,11 +44,17 @@ module Sai
     #
     # @return [Boolean] `true` if the terminal supports ANSI colors (4-bit), otherwise `false`
     # @rbs () -> bool
-    def ansi?: () -> bool
+    def self.ansi?: () -> bool
 
-    alias bit4? ansi?
+    alias self.color16? self.ansi?
 
-    alias four_bit? ansi?
+    alias self.colour16? self.ansi?
+
+    alias self.four_bit? self.ansi?
+
+    alias self.sixteen_color? self.ansi?
+
+    alias self.sixteen_colour? self.ansi?
 
     # Check if the terminal supports basic colors (3-bit)
     #
@@ -67,11 +68,17 @@ module Sai
     #
     # @return [Boolean] `true` if the terminal supports basic colors (3-bit), otherwise `false`
     # @rbs () -> bool
-    def basic?: () -> bool
+    def self.basic?: () -> bool
 
-    alias bit3? basic?
+    alias self.color8? self.basic?
 
-    alias three_bit? basic?
+    alias self.colour8? self.basic?
+
+    alias self.eight_color? self.basic?
+
+    alias self.eight_colour? self.basic?
+
+    alias self.three_bit? self.basic?
 
     # Check if the terminal supports color output
     #
@@ -85,7 +92,7 @@ module Sai
     #
     # @return [Boolean] `true` if the terminal supports color output, otherwise `false`
     # @rbs () -> bool
-    def color?: () -> bool
+    def self.color?: () -> bool
 
     # Check if the terminal supports true color (24-bit)
     #
@@ -99,10 +106,16 @@ module Sai
     #
     # @return [Boolean] `true` if the terminal supports true color (24-bit), otherwise `false`
     # @rbs () -> bool
-    def true_color?: () -> bool
+    def self.true_color?: () -> bool
 
-    alias bit24? true_color?
+    alias self.color16m? self.true_color?
 
-    alias twenty_four_bit? true_color?
+    alias self.colour16m? self.true_color?
+
+    alias self.sixteen_million_color? self.true_color?
+
+    alias self.sixteen_million_colour? self.true_color?
+
+    alias self.twenty_for_bit? self.true_color?
   end
 end

--- a/sig/sai/support.rbs
+++ b/sig/sai/support.rbs
@@ -21,6 +21,22 @@ module Sai
     # @rbs (Integer color_mode) -> void
     def initialize: (Integer color_mode) -> void
 
+    # Check if the terminal supports 256 colors (8-bit)
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since 0.1.0
+    #
+    # @api public
+    #
+    # @example Check if the terminal supports 256 colors
+    #   Sai.advanced? # => true
+    #
+    # @return [Boolean] `true` if the terminal supports 256 colors (8-bit), otherwise `false`
+    # @rbs () -> bool
+    def advanced?: () -> bool
+
+    alias eight_bit? advanced?
+
     # Check if the terminal supports ANSI colors (4-bit)
     #
     # @author {https://aaronmallen.me Aaron Allen}
@@ -56,22 +72,6 @@ module Sai
     alias bit3? basic?
 
     alias three_bit? basic?
-
-    # Check if the terminal supports 256 colors (8-bit)
-    #
-    # @author {https://aaronmallen.me Aaron Allen}
-    # @since 0.1.0
-    #
-    # @api public
-    #
-    # @example Check if the terminal supports 256 colors
-    #   Sai.bit8? # => true
-    #
-    # @return [Boolean] `true` if the terminal supports 256 colors (8-bit), otherwise `false`
-    # @rbs () -> bool
-    def bit8?: () -> bool
-
-    alias eight_bit? bit8?
 
     # Check if the terminal supports color output
     #

--- a/sig/sai/terminal/capabilities.rbs
+++ b/sig/sai/terminal/capabilities.rbs
@@ -20,6 +20,17 @@ module Sai
       # @rbs () -> Integer
       def self.detect_color_support: () -> Integer
 
+      # Check for 256 color (8-bit) support
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since 0.1.0
+      #
+      # @api private
+      #
+      # @return [Boolean] `true` if the terminal supports 256 colors, otherwise `false`
+      # @rbs () -> bool
+      private def self.advanced?: () -> bool
+
       # Check for ANSI color support
       #
       # @author {https://aaronmallen.me Aaron Allen}
@@ -41,17 +52,6 @@ module Sai
       # @return [Boolean] `true` if the terminal supports basic colors, otherwise `false`
       # @rbs () -> bool
       private def self.basic?: () -> bool
-
-      # Check for 256 color (8-bit) support
-      #
-      # @author {https://aaronmallen.me Aaron Allen}
-      # @since 0.1.0
-      #
-      # @api private
-      #
-      # @return [Boolean] `true` if the terminal supports 256 colors, otherwise `false`
-      # @rbs () -> bool
-      private def self.bit8?: () -> bool
 
       # Check for NO_COLOR environment variable
       #

--- a/sig/sai/terminal/color_mode.rbs
+++ b/sig/sai/terminal/color_mode.rbs
@@ -47,7 +47,7 @@ module Sai
       # @api private
       #
       # @return [Integer] the color mode
-      BIT8: Integer
+      ADVANCED: Integer
 
       # The terminal supports 16 million colors (24-bit)
       #

--- a/spec/sai/conversion/color_sequence_spec.rb
+++ b/spec/sai/conversion/color_sequence_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Sai::Conversion::ColorSequence do
     end
 
     context 'when in 8-bit color mode' do
-      let(:mode) { Sai::Terminal::ColorMode::BIT8 }
+      let(:mode) { Sai::Terminal::ColorMode::ADVANCED }
 
       context 'when given grayscale color' do
         let(:color) { [128, 128, 128] }

--- a/spec/sai/decorator_spec.rb
+++ b/spec/sai/decorator_spec.rb
@@ -4,9 +4,9 @@ require 'spec_helper'
 
 RSpec.describe Sai::Decorator do
   describe '.new' do
-    subject(:decorator) { described_class.new(color_mode) }
+    subject(:decorator) { described_class.new(mode: mode) }
 
-    let(:color_mode) { Sai::Terminal::ColorMode::TRUE_COLOR }
+    let(:mode) { Sai::Terminal::ColorMode::TRUE_COLOR }
 
     it 'is expected to initialize with empty styles' do
       expect(decorator.instance_variable_get(:@styles)).to eq([])
@@ -20,16 +20,16 @@ RSpec.describe Sai::Decorator do
       expect(decorator.instance_variable_get(:@background)).to be_nil
     end
 
-    it 'is expected to initialize with the provided color mode' do
-      expect(decorator.instance_variable_get(:@color_mode)).to eq(color_mode)
+    it 'is expected to initialize with the provided mode' do
+      expect(decorator.instance_variable_get(:@mode)).to eq(mode)
     end
   end
 
   describe '#decorate' do
     subject(:decorated_text) { decorator.decorate(text) }
 
-    let(:decorator) { described_class.new(color_mode) }
-    let(:color_mode) { Sai::Terminal::ColorMode::TRUE_COLOR }
+    let(:decorator) { described_class.new(mode: mode) }
+    let(:mode) { Sai::Terminal::ColorMode::TRUE_COLOR }
     let(:text) { 'Hello, world!' }
 
     context 'when no styles or colors are applied' do
@@ -74,7 +74,8 @@ RSpec.describe Sai::Decorator do
   describe '#hex' do
     subject(:hex_decorator) { decorator.hex(code) }
 
-    let(:decorator) { described_class.new(Sai::Terminal::ColorMode::TRUE_COLOR) }
+    let(:decorator) { described_class.new(mode: mode) }
+    let(:mode) { Sai::Terminal::ColorMode::TRUE_COLOR }
 
     context 'when given a valid hex code' do
       let(:code) { '#EB4133' }
@@ -108,7 +109,8 @@ RSpec.describe Sai::Decorator do
   describe '#on_hex' do
     subject(:on_hex_decorator) { decorator.on_hex(code) }
 
-    let(:decorator) { described_class.new(Sai::Terminal::ColorMode::TRUE_COLOR) }
+    let(:decorator) { described_class.new(mode: mode) }
+    let(:mode) { Sai::Terminal::ColorMode::TRUE_COLOR }
 
     context 'when given a valid hex code' do
       let(:code) { '#EB4133' }
@@ -142,7 +144,8 @@ RSpec.describe Sai::Decorator do
   describe '#rgb' do
     subject(:rgb_decorator) { decorator.rgb(red, green, blue) }
 
-    let(:decorator) { described_class.new(Sai::Terminal::ColorMode::TRUE_COLOR) }
+    let(:decorator) { described_class.new(mode: mode) }
+    let(:mode) { Sai::Terminal::ColorMode::TRUE_COLOR }
     let(:red) { 235 }
     let(:green) { 65 }
     let(:blue) { 51 }
@@ -177,7 +180,8 @@ RSpec.describe Sai::Decorator do
   describe '#on_rgb' do
     subject(:on_rgb_decorator) { decorator.on_rgb(red, green, blue) }
 
-    let(:decorator) { described_class.new(Sai::Terminal::ColorMode::TRUE_COLOR) }
+    let(:decorator) { described_class.new(mode: mode) }
+    let(:mode) { Sai::Terminal::ColorMode::TRUE_COLOR }
     let(:red) { 235 }
     let(:green) { 65 }
     let(:blue) { 51 }
@@ -209,12 +213,63 @@ RSpec.describe Sai::Decorator do
     end
   end
 
+  describe 'color mode behavior' do
+    subject(:decorated_text) { decorator.hex('#CD0000').decorate('test') }
+
+    let(:decorator) { described_class.new(mode: Sai.mode.auto) }
+
+    before do
+      allow(Sai::Terminal::Capabilities).to receive(:detect_color_support).and_return(terminal_support)
+    end
+
+    context 'when terminal supports true color' do
+      let(:terminal_support) { Sai::Terminal::ColorMode::TRUE_COLOR }
+
+      it 'is expected to use true color codes' do
+        expect(decorated_text).to eq("\e[38;2;205;0;0mtest\e[0m")
+      end
+    end
+
+    context 'when terminal supports 8-bit color' do
+      let(:terminal_support) { Sai::Terminal::ColorMode::ADVANCED }
+
+      it 'is expected to use 8-bit color codes' do
+        expect(decorated_text).to eq("\e[38;5;160mtest\e[0m")
+      end
+    end
+
+    context 'when terminal supports 4-bit color' do
+      let(:terminal_support) { Sai::Terminal::ColorMode::ANSI }
+
+      it 'is expected to use 4-bit color codes' do
+        expect(decorated_text).to eq("\e[31mtest\e[0m")
+      end
+    end
+
+    context 'when terminal supports only basic color' do
+      let(:terminal_support) { Sai::Terminal::ColorMode::BASIC }
+
+      it 'is expected to use basic color codes' do
+        expect(decorated_text).to eq("\e[31mtest\e[0m")
+      end
+    end
+
+    context 'when terminal has no color support' do
+      let(:terminal_support) { Sai::Terminal::ColorMode::NO_COLOR }
+
+      it 'is expected to return unmodified text' do
+        expect(decorated_text).to eq('test')
+      end
+    end
+  end
+
   # Test each named color method
   Sai::ANSI::COLOR_NAMES.each_key do |color|
     describe "##{color}" do
       subject(:color_decorator) { decorator.public_send(color) }
 
-      let(:decorator) { described_class.new(Sai::Terminal::ColorMode::TRUE_COLOR) }
+      let(:decorator) { described_class.new(mode: mode) }
+      let(:mode) { Sai::Terminal::ColorMode::TRUE_COLOR }
 
       it { is_expected.to be_an_instance_of(described_class) }
 
@@ -236,7 +291,8 @@ RSpec.describe Sai::Decorator do
     describe "#on_#{color}" do
       subject(:background_color_decorator) { decorator.public_send(:"on_#{color}") }
 
-      let(:decorator) { described_class.new(Sai::Terminal::ColorMode::TRUE_COLOR) }
+      let(:decorator) { described_class.new(mode: mode) }
+      let(:mode) { Sai::Terminal::ColorMode::TRUE_COLOR }
 
       it { is_expected.to be_an_instance_of(described_class) }
 
@@ -261,7 +317,8 @@ RSpec.describe Sai::Decorator do
     describe "##{style}" do
       subject(:style_decorator) { decorator.public_send(style) }
 
-      let(:decorator) { described_class.new(Sai::Terminal::ColorMode::TRUE_COLOR) }
+      let(:decorator) { described_class.new(mode: mode) }
+      let(:mode) { Sai::Terminal::ColorMode::TRUE_COLOR }
 
       it { is_expected.to be_an_instance_of(described_class) }
 

--- a/spec/sai/decorator_spec.rb
+++ b/spec/sai/decorator_spec.rb
@@ -213,6 +213,20 @@ RSpec.describe Sai::Decorator do
     end
   end
 
+  describe '#with_mode' do
+    subject(:with_mode) { decorator.with_mode(color_mode) }
+
+    let(:decorator) { described_class.new(mode: Sai.mode.true_color) }
+    let(:color_mode) { Sai.mode.no_color }
+
+    it 'is expected to set the color mode' do
+      before_mode_set = decorator.hex('#CD0000').decorate('text')
+      after_mode_set = with_mode.decorate('text')
+
+      expect(after_mode_set).not_to eq(before_mode_set)
+    end
+  end
+
   describe 'color mode behavior' do
     subject(:decorated_text) { decorator.hex('#CD0000').decorate('test') }
 

--- a/spec/sai/mode_selector_spec.rb
+++ b/spec/sai/mode_selector_spec.rb
@@ -1,0 +1,187 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Sai::ModeSelector do
+  describe '.advanced' do
+    subject(:advanced) { described_class.advanced }
+
+    it { is_expected.to eq(Sai::Terminal::ColorMode::ADVANCED) }
+  end
+
+  describe '.advanced_auto' do
+    subject(:advanced_auto) { described_class.advanced_auto }
+
+    before do
+      allow(Sai::Terminal::Capabilities).to receive(:detect_color_support).and_return(color_support)
+    end
+
+    context 'when terminal supports true color' do
+      let(:color_support) { Sai::Terminal::ColorMode::TRUE_COLOR }
+
+      it { is_expected.to eq(Sai::Terminal::ColorMode::ADVANCED) }
+    end
+
+    context 'when terminal supports 8-bit color' do
+      let(:color_support) { Sai::Terminal::ColorMode::ADVANCED }
+
+      it { is_expected.to eq(Sai::Terminal::ColorMode::ADVANCED) }
+    end
+
+    context 'when terminal only supports 4-bit color' do
+      let(:color_support) { Sai::Terminal::ColorMode::ANSI }
+
+      it { is_expected.to eq(Sai::Terminal::ColorMode::ANSI) }
+    end
+
+    context 'when terminal only supports 3-bit color' do
+      let(:color_support) { Sai::Terminal::ColorMode::BASIC }
+
+      it { is_expected.to eq(Sai::Terminal::ColorMode::BASIC) }
+    end
+
+    context 'when terminal has no color support' do
+      let(:color_support) { Sai::Terminal::ColorMode::NO_COLOR }
+
+      it { is_expected.to eq(Sai::Terminal::ColorMode::NO_COLOR) }
+    end
+  end
+
+  describe '.ansi' do
+    subject(:ansi) { described_class.ansi }
+
+    it { is_expected.to eq(Sai::Terminal::ColorMode::ANSI) }
+  end
+
+  describe '.ansi_auto' do
+    subject(:ansi_auto) { described_class.ansi_auto }
+
+    before do
+      allow(Sai::Terminal::Capabilities).to receive(:detect_color_support).and_return(color_support)
+    end
+
+    context 'when terminal supports true color' do
+      let(:color_support) { Sai::Terminal::ColorMode::TRUE_COLOR }
+
+      it { is_expected.to eq(Sai::Terminal::ColorMode::ANSI) }
+    end
+
+    context 'when terminal supports 8-bit color' do
+      let(:color_support) { Sai::Terminal::ColorMode::ADVANCED }
+
+      it { is_expected.to eq(Sai::Terminal::ColorMode::ANSI) }
+    end
+
+    context 'when terminal supports 4-bit color' do
+      let(:color_support) { Sai::Terminal::ColorMode::ANSI }
+
+      it { is_expected.to eq(Sai::Terminal::ColorMode::ANSI) }
+    end
+
+    context 'when terminal only supports 3-bit color' do
+      let(:color_support) { Sai::Terminal::ColorMode::BASIC }
+
+      it { is_expected.to eq(Sai::Terminal::ColorMode::BASIC) }
+    end
+
+    context 'when terminal has no color support' do
+      let(:color_support) { Sai::Terminal::ColorMode::NO_COLOR }
+
+      it { is_expected.to eq(Sai::Terminal::ColorMode::NO_COLOR) }
+    end
+  end
+
+  describe '.auto' do
+    subject(:auto) { described_class.auto }
+
+    before do
+      allow(Sai::Terminal::Capabilities).to receive(:detect_color_support).and_return(color_support)
+    end
+
+    context 'when terminal supports true color' do
+      let(:color_support) { Sai::Terminal::ColorMode::TRUE_COLOR }
+
+      it { is_expected.to eq(Sai::Terminal::ColorMode::TRUE_COLOR) }
+    end
+
+    context 'when terminal supports 8-bit color' do
+      let(:color_support) { Sai::Terminal::ColorMode::ADVANCED }
+
+      it { is_expected.to eq(Sai::Terminal::ColorMode::ADVANCED) }
+    end
+
+    context 'when terminal supports 4-bit color' do
+      let(:color_support) { Sai::Terminal::ColorMode::ANSI }
+
+      it { is_expected.to eq(Sai::Terminal::ColorMode::ANSI) }
+    end
+
+    context 'when terminal supports 3-bit color' do
+      let(:color_support) { Sai::Terminal::ColorMode::BASIC }
+
+      it { is_expected.to eq(Sai::Terminal::ColorMode::BASIC) }
+    end
+
+    context 'when terminal has no color support' do
+      let(:color_support) { Sai::Terminal::ColorMode::NO_COLOR }
+
+      it { is_expected.to eq(Sai::Terminal::ColorMode::NO_COLOR) }
+    end
+  end
+
+  describe '.basic' do
+    subject(:basic) { described_class.basic }
+
+    it { is_expected.to eq(Sai::Terminal::ColorMode::BASIC) }
+  end
+
+  describe '.basic_auto' do
+    subject(:basic_auto) { described_class.basic_auto }
+
+    before do
+      allow(Sai::Terminal::Capabilities).to receive(:detect_color_support).and_return(color_support)
+    end
+
+    context 'when terminal supports true color' do
+      let(:color_support) { Sai::Terminal::ColorMode::TRUE_COLOR }
+
+      it { is_expected.to eq(Sai::Terminal::ColorMode::BASIC) }
+    end
+
+    context 'when terminal supports 8-bit color' do
+      let(:color_support) { Sai::Terminal::ColorMode::ADVANCED }
+
+      it { is_expected.to eq(Sai::Terminal::ColorMode::BASIC) }
+    end
+
+    context 'when terminal supports 4-bit color' do
+      let(:color_support) { Sai::Terminal::ColorMode::ANSI }
+
+      it { is_expected.to eq(Sai::Terminal::ColorMode::BASIC) }
+    end
+
+    context 'when terminal supports 3-bit color' do
+      let(:color_support) { Sai::Terminal::ColorMode::BASIC }
+
+      it { is_expected.to eq(Sai::Terminal::ColorMode::BASIC) }
+    end
+
+    context 'when terminal has no color support' do
+      let(:color_support) { Sai::Terminal::ColorMode::NO_COLOR }
+
+      it { is_expected.to eq(Sai::Terminal::ColorMode::NO_COLOR) }
+    end
+  end
+
+  describe '.no_color' do
+    subject(:no_color) { described_class.no_color }
+
+    it { is_expected.to eq(Sai::Terminal::ColorMode::NO_COLOR) }
+  end
+
+  describe '.true_color' do
+    subject(:true_color) { described_class.true_color }
+
+    it { is_expected.to eq(Sai::Terminal::ColorMode::TRUE_COLOR) }
+  end
+end

--- a/spec/sai/support_spec.rb
+++ b/spec/sai/support_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe Sai::Support do
       it { expect(support.ansi?).to be true }
     end
 
-    context 'when color mode is BIT8' do
-      let(:color_mode) { Sai::Terminal::ColorMode::BIT8 }
+    context 'when color mode is ADVANCED' do
+      let(:color_mode) { Sai::Terminal::ColorMode::ADVANCED }
 
       it { expect(support.ansi?).to be true }
     end
@@ -56,8 +56,8 @@ RSpec.describe Sai::Support do
       it { expect(support.basic?).to be true }
     end
 
-    context 'when color mode is BIT8' do
-      let(:color_mode) { Sai::Terminal::ColorMode::BIT8 }
+    context 'when color mode is ADVANCED' do
+      let(:color_mode) { Sai::Terminal::ColorMode::ADVANCED }
 
       it { expect(support.basic?).to be true }
     end
@@ -69,35 +69,35 @@ RSpec.describe Sai::Support do
     end
   end
 
-  describe '#bit8?' do
+  describe '#advanced?' do
     context 'when color mode is NO_COLOR' do
       let(:color_mode) { Sai::Terminal::ColorMode::NO_COLOR }
 
-      it { expect(support.bit8?).to be false }
+      it { expect(support.advanced?).to be false }
     end
 
     context 'when color mode is BASIC' do
       let(:color_mode) { Sai::Terminal::ColorMode::BASIC }
 
-      it { expect(support.bit8?).to be false }
+      it { expect(support.advanced?).to be false }
     end
 
     context 'when color mode is ANSI' do
       let(:color_mode) { Sai::Terminal::ColorMode::ANSI }
 
-      it { expect(support.bit8?).to be false }
+      it { expect(support.advanced?).to be false }
     end
 
-    context 'when color mode is BIT8' do
-      let(:color_mode) { Sai::Terminal::ColorMode::BIT8 }
+    context 'when color mode is ADVANCED' do
+      let(:color_mode) { Sai::Terminal::ColorMode::ADVANCED }
 
-      it { expect(support.bit8?).to be true }
+      it { expect(support.advanced?).to be true }
     end
 
     context 'when color mode is TRUE_COLOR' do
       let(:color_mode) { Sai::Terminal::ColorMode::TRUE_COLOR }
 
-      it { expect(support.bit8?).to be true }
+      it { expect(support.advanced?).to be true }
     end
   end
 
@@ -120,8 +120,8 @@ RSpec.describe Sai::Support do
       it { expect(support.color?).to be true }
     end
 
-    context 'when color mode is BIT8' do
-      let(:color_mode) { Sai::Terminal::ColorMode::BIT8 }
+    context 'when color mode is ADVANCED' do
+      let(:color_mode) { Sai::Terminal::ColorMode::ADVANCED }
 
       it { expect(support.color?).to be true }
     end
@@ -152,8 +152,8 @@ RSpec.describe Sai::Support do
       it { expect(support.true_color?).to be false }
     end
 
-    context 'when color mode is BIT8' do
-      let(:color_mode) { Sai::Terminal::ColorMode::BIT8 }
+    context 'when color mode is ADVANCED' do
+      let(:color_mode) { Sai::Terminal::ColorMode::ADVANCED }
 
       it { expect(support.true_color?).to be false }
     end

--- a/spec/sai/support_spec.rb
+++ b/spec/sai/support_spec.rb
@@ -3,165 +3,177 @@
 require 'spec_helper'
 
 RSpec.describe Sai::Support do
-  subject(:support) { described_class.new(color_mode) }
+  before do
+    allow(Sai::Terminal::Capabilities).to receive(:detect_color_support).and_return(color_mode)
+  end
 
-  describe '#ansi?' do
-    context 'when color mode is NO_COLOR' do
-      let(:color_mode) { Sai::Terminal::ColorMode::NO_COLOR }
+  describe '.advanced?' do
+    subject(:advanced?) { described_class.advanced? }
 
-      it { expect(support.ansi?).to be false }
-    end
-
-    context 'when color mode is BASIC' do
-      let(:color_mode) { Sai::Terminal::ColorMode::BASIC }
-
-      it { expect(support.ansi?).to be false }
-    end
-
-    context 'when color mode is ANSI' do
-      let(:color_mode) { Sai::Terminal::ColorMode::ANSI }
-
-      it { expect(support.ansi?).to be true }
-    end
-
-    context 'when color mode is ADVANCED' do
-      let(:color_mode) { Sai::Terminal::ColorMode::ADVANCED }
-
-      it { expect(support.ansi?).to be true }
-    end
-
-    context 'when color mode is TRUE_COLOR' do
+    context 'when terminal supports true color' do
       let(:color_mode) { Sai::Terminal::ColorMode::TRUE_COLOR }
 
-      it { expect(support.ansi?).to be true }
+      it { is_expected.to be true }
+    end
+
+    context 'when terminal supports 8-bit color' do
+      let(:color_mode) { Sai::Terminal::ColorMode::ADVANCED }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when terminal supports 4-bit color' do
+      let(:color_mode) { Sai::Terminal::ColorMode::ANSI }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when terminal supports 3-bit color' do
+      let(:color_mode) { Sai::Terminal::ColorMode::BASIC }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when terminal has no color support' do
+      let(:color_mode) { Sai::Terminal::ColorMode::NO_COLOR }
+
+      it { is_expected.to be false }
     end
   end
 
-  describe '#basic?' do
-    context 'when color mode is NO_COLOR' do
-      let(:color_mode) { Sai::Terminal::ColorMode::NO_COLOR }
+  describe '.ansi?' do
+    subject(:ansi?) { described_class.ansi? }
 
-      it { expect(support.basic?).to be false }
-    end
-
-    context 'when color mode is BASIC' do
-      let(:color_mode) { Sai::Terminal::ColorMode::BASIC }
-
-      it { expect(support.basic?).to be true }
-    end
-
-    context 'when color mode is ANSI' do
-      let(:color_mode) { Sai::Terminal::ColorMode::ANSI }
-
-      it { expect(support.basic?).to be true }
-    end
-
-    context 'when color mode is ADVANCED' do
-      let(:color_mode) { Sai::Terminal::ColorMode::ADVANCED }
-
-      it { expect(support.basic?).to be true }
-    end
-
-    context 'when color mode is TRUE_COLOR' do
+    context 'when terminal supports true color' do
       let(:color_mode) { Sai::Terminal::ColorMode::TRUE_COLOR }
 
-      it { expect(support.basic?).to be true }
+      it { is_expected.to be true }
+    end
+
+    context 'when terminal supports 8-bit color' do
+      let(:color_mode) { Sai::Terminal::ColorMode::ADVANCED }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when terminal supports 4-bit color' do
+      let(:color_mode) { Sai::Terminal::ColorMode::ANSI }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when terminal supports 3-bit color' do
+      let(:color_mode) { Sai::Terminal::ColorMode::BASIC }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when terminal has no color support' do
+      let(:color_mode) { Sai::Terminal::ColorMode::NO_COLOR }
+
+      it { is_expected.to be false }
     end
   end
 
-  describe '#advanced?' do
-    context 'when color mode is NO_COLOR' do
-      let(:color_mode) { Sai::Terminal::ColorMode::NO_COLOR }
+  describe '.basic?' do
+    subject(:basic?) { described_class.basic? }
 
-      it { expect(support.advanced?).to be false }
-    end
-
-    context 'when color mode is BASIC' do
-      let(:color_mode) { Sai::Terminal::ColorMode::BASIC }
-
-      it { expect(support.advanced?).to be false }
-    end
-
-    context 'when color mode is ANSI' do
-      let(:color_mode) { Sai::Terminal::ColorMode::ANSI }
-
-      it { expect(support.advanced?).to be false }
-    end
-
-    context 'when color mode is ADVANCED' do
-      let(:color_mode) { Sai::Terminal::ColorMode::ADVANCED }
-
-      it { expect(support.advanced?).to be true }
-    end
-
-    context 'when color mode is TRUE_COLOR' do
+    context 'when terminal supports true color' do
       let(:color_mode) { Sai::Terminal::ColorMode::TRUE_COLOR }
 
-      it { expect(support.advanced?).to be true }
+      it { is_expected.to be true }
+    end
+
+    context 'when terminal supports 8-bit color' do
+      let(:color_mode) { Sai::Terminal::ColorMode::ADVANCED }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when terminal supports 4-bit color' do
+      let(:color_mode) { Sai::Terminal::ColorMode::ANSI }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when terminal supports 3-bit color' do
+      let(:color_mode) { Sai::Terminal::ColorMode::BASIC }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when terminal has no color support' do
+      let(:color_mode) { Sai::Terminal::ColorMode::NO_COLOR }
+
+      it { is_expected.to be false }
     end
   end
 
-  describe '#color?' do
-    context 'when color mode is NO_COLOR' do
-      let(:color_mode) { Sai::Terminal::ColorMode::NO_COLOR }
+  describe '.color?' do
+    subject(:color?) { described_class.color? }
 
-      it { expect(support.color?).to be false }
-    end
-
-    context 'when color mode is BASIC' do
-      let(:color_mode) { Sai::Terminal::ColorMode::BASIC }
-
-      it { expect(support.color?).to be true }
-    end
-
-    context 'when color mode is ANSI' do
-      let(:color_mode) { Sai::Terminal::ColorMode::ANSI }
-
-      it { expect(support.color?).to be true }
-    end
-
-    context 'when color mode is ADVANCED' do
-      let(:color_mode) { Sai::Terminal::ColorMode::ADVANCED }
-
-      it { expect(support.color?).to be true }
-    end
-
-    context 'when color mode is TRUE_COLOR' do
+    context 'when terminal supports true color' do
       let(:color_mode) { Sai::Terminal::ColorMode::TRUE_COLOR }
 
-      it { expect(support.color?).to be true }
+      it { is_expected.to be true }
+    end
+
+    context 'when terminal supports 8-bit color' do
+      let(:color_mode) { Sai::Terminal::ColorMode::ADVANCED }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when terminal supports 4-bit color' do
+      let(:color_mode) { Sai::Terminal::ColorMode::ANSI }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when terminal supports 3-bit color' do
+      let(:color_mode) { Sai::Terminal::ColorMode::BASIC }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when terminal has no color support' do
+      let(:color_mode) { Sai::Terminal::ColorMode::NO_COLOR }
+
+      it { is_expected.to be false }
     end
   end
 
-  describe '#true_color?' do
-    context 'when color mode is NO_COLOR' do
-      let(:color_mode) { Sai::Terminal::ColorMode::NO_COLOR }
+  describe '.true_color?' do
+    subject(:true_color?) { described_class.true_color? }
 
-      it { expect(support.true_color?).to be false }
-    end
-
-    context 'when color mode is BASIC' do
-      let(:color_mode) { Sai::Terminal::ColorMode::BASIC }
-
-      it { expect(support.true_color?).to be false }
-    end
-
-    context 'when color mode is ANSI' do
-      let(:color_mode) { Sai::Terminal::ColorMode::ANSI }
-
-      it { expect(support.true_color?).to be false }
-    end
-
-    context 'when color mode is ADVANCED' do
-      let(:color_mode) { Sai::Terminal::ColorMode::ADVANCED }
-
-      it { expect(support.true_color?).to be false }
-    end
-
-    context 'when color mode is TRUE_COLOR' do
+    context 'when terminal supports true color' do
       let(:color_mode) { Sai::Terminal::ColorMode::TRUE_COLOR }
 
-      it { expect(support.true_color?).to be true }
+      it { is_expected.to be true }
+    end
+
+    context 'when terminal supports 8-bit color' do
+      let(:color_mode) { Sai::Terminal::ColorMode::ADVANCED }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when terminal supports 4-bit color' do
+      let(:color_mode) { Sai::Terminal::ColorMode::ANSI }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when terminal supports 3-bit color' do
+      let(:color_mode) { Sai::Terminal::ColorMode::BASIC }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when terminal has no color support' do
+      let(:color_mode) { Sai::Terminal::ColorMode::NO_COLOR }
+
+      it { is_expected.to be false }
     end
   end
 end

--- a/spec/sai_spec.rb
+++ b/spec/sai_spec.rb
@@ -26,6 +26,12 @@ RSpec.describe Sai do
 
     let(:instance) { including_class.new }
 
+    describe '#color_mode' do
+      subject(:color_mode) { instance.color_mode }
+
+      it { is_expected.to eq(Sai::ModeSelector) }
+    end
+
     describe '#decorator' do
       subject(:decorator) { instance.decorator(mode: mode) }
 

--- a/spec/sai_spec.rb
+++ b/spec/sai_spec.rb
@@ -2,13 +2,9 @@
 
 require 'spec_helper'
 
+# frozen_string_literal: true
+
 RSpec.describe Sai do
-  let(:color_mode) { Sai::Terminal::ColorMode::TRUE_COLOR }
-
-  before do
-    allow(Sai::Terminal::Capabilities).to receive(:detect_color_support).and_return(color_mode)
-  end
-
   describe '.mode' do
     subject(:mode) { described_class.mode }
 
@@ -18,9 +14,7 @@ RSpec.describe Sai do
   describe '.support' do
     subject(:support) { described_class.support }
 
-    it 'is expected to return a frozen Support instance' do
-      expect(support).to eq(Sai::Support)
-    end
+    it { is_expected.to eq(Sai::Support) }
   end
 
   describe 'module inclusion' do
@@ -33,26 +27,34 @@ RSpec.describe Sai do
     let(:instance) { including_class.new }
 
     describe '#decorator' do
-      subject(:decorator) { instance.decorator }
+      subject(:decorator) { instance.decorator(mode: mode) }
 
       let(:decorator_double) { instance_double(Sai::Decorator) }
+      let(:mode) { described_class.mode.auto }
 
       before do
-        allow(Sai::Decorator).to receive(:new).with(color_mode).and_return(decorator_double)
-        decorator
+        allow(Sai::Decorator).to receive(:new).with(mode: mode).and_return(decorator_double)
       end
 
-      it 'is expected to return a new Decorator instance' do
-        expect(Sai::Decorator).to have_received(:new).with(color_mode)
+      it 'is expected to return a new Decorator instance with the specified mode' do
+        decorator
+        expect(Sai::Decorator).to have_received(:new).with(mode: mode)
+      end
+
+      context 'when no mode is specified' do
+        subject(:decorator) { instance.decorator }
+
+        it 'is expected to use auto mode by default' do
+          decorator
+          expect(Sai::Decorator).to have_received(:new).with(mode: described_class.mode.auto)
+        end
       end
     end
 
     describe '#terminal_color_support' do
       subject(:terminal_color_support) { instance.terminal_color_support }
 
-      it 'is expected to return the support instance' do
-        expect(terminal_color_support).to be(described_class.support)
-      end
+      it { is_expected.to eq(Sai::Support) }
     end
   end
 
@@ -63,15 +65,11 @@ RSpec.describe Sai do
       let(:decorator_instance) { instance_spy(Sai::Decorator) }
 
       before do
-        allow(Sai::Decorator).to receive(:new).and_return(decorator_instance)
+        allow(Sai::Decorator).to receive(:new).with(mode: described_class.mode.auto).and_return(decorator_instance)
+      end
+
+      it 'is expected to delegate the method call to a new Decorator instance' do
         delegated_call
-      end
-
-      it 'is expected to create a new Decorator with the current color mode' do
-        expect(Sai::Decorator).to have_received(:new).with(color_mode)
-      end
-
-      it 'is expected to delegate the method call to the Decorator instance' do
         expect(decorator_instance).to have_received(method).with(no_args)
       end
     end
@@ -82,15 +80,11 @@ RSpec.describe Sai do
       let(:decorator_instance) { instance_spy(Sai::Decorator) }
 
       before do
-        allow(Sai::Decorator).to receive(:new).and_return(decorator_instance)
+        allow(Sai::Decorator).to receive(:new).with(mode: described_class.mode.auto).and_return(decorator_instance)
+      end
+
+      it 'is expected to delegate the method call to a new Decorator instance' do
         delegated_call
-      end
-
-      it 'is expected to create a new Decorator with the current color mode' do
-        expect(Sai::Decorator).to have_received(:new).with(color_mode)
-      end
-
-      it 'is expected to delegate the method call to the Decorator instance' do
         expect(decorator_instance).to have_received(:hex).with('#FF0000')
       end
     end
@@ -101,20 +95,15 @@ RSpec.describe Sai do
       let(:decorator_instance) { instance_spy(Sai::Decorator) }
 
       before do
-        allow(Sai::Decorator).to receive(:new).and_return(decorator_instance)
+        allow(Sai::Decorator).to receive(:new).with(mode: described_class.mode.auto).and_return(decorator_instance)
+      end
+
+      it 'is expected to delegate the method call to a new Decorator instance' do
         delegated_call
-      end
-
-      it 'is expected to create a new Decorator with the current color mode' do
-        expect(Sai::Decorator).to have_received(:new).with(color_mode)
-      end
-
-      it 'is expected to delegate the method call to the Decorator instance' do
         expect(decorator_instance).to have_received(:rgb).with(255, 0, 0)
       end
     end
 
-    # Test methods without arguments
     describe '.red' do
       include_examples 'a delegated method without arguments', :red
     end
@@ -131,7 +120,6 @@ RSpec.describe Sai do
       include_examples 'a delegated method without arguments', :italic
     end
 
-    # Test methods with arguments
     describe '.hex' do
       include_examples 'a delegated method with hex argument'
     end
@@ -145,53 +133,6 @@ RSpec.describe Sai do
         it "is not expected to respond to ##{method}" do
           expect(described_class).not_to respond_to(method)
         end
-      end
-    end
-  end
-
-  describe 'thread safety' do
-    describe '.color_mode' do
-      subject(:color_mode_value) { described_class.send(:color_mode) }
-
-      before do
-        Thread.current[:sai_color_mode] = nil
-      end
-
-      it 'is expected to store color mode in thread local storage' do
-        expect { color_mode_value }
-          .to change { Thread.current[:sai_color_mode] }
-          .from(nil)
-          .to(color_mode)
-      end
-
-      it 'is expected to memoize the color mode per thread' do # rubocop:disable RSpec/MultipleExpectations
-        first_call = described_class.send(:color_mode)
-        described_class.send(:color_mode)
-
-        expect(Sai::Terminal::Capabilities)
-          .to have_received(:detect_color_support).once
-        expect(first_call).to eq(color_mode)
-      end
-    end
-
-    describe 'thread isolation' do
-      it 'is expected to maintain color mode isolation' do
-        Thread.current[:sai_color_mode] = color_mode
-        alternate_thread = Thread.new do
-          Thread.current[:sai_color_mode] = Sai::Terminal::ColorMode::BASIC
-          Thread.current[:sai_color_mode]
-        end
-
-        expect(alternate_thread.value).to eq(Sai::Terminal::ColorMode::BASIC)
-      end
-
-      it 'is expected to maintain the original thread color mode' do
-        Thread.current[:sai_color_mode] = color_mode
-        Thread.new do
-          Thread.current[:sai_color_mode] = Sai::Terminal::ColorMode::BASIC
-        end.join
-
-        expect(Thread.current[:sai_color_mode]).to eq(color_mode)
       end
     end
   end

--- a/spec/sai_spec.rb
+++ b/spec/sai_spec.rb
@@ -9,6 +9,12 @@ RSpec.describe Sai do
     allow(Sai::Terminal::Capabilities).to receive(:detect_color_support).and_return(color_mode)
   end
 
+  describe '.mode' do
+    subject(:mode) { described_class.mode }
+
+    it { is_expected.to eq(Sai::ModeSelector) }
+  end
+
   describe '.support' do
     subject(:support) { described_class.support }
 

--- a/spec/sai_spec.rb
+++ b/spec/sai_spec.rb
@@ -19,14 +19,7 @@ RSpec.describe Sai do
     subject(:support) { described_class.support }
 
     it 'is expected to return a frozen Support instance' do
-      expect(support).to be_a(Sai::Support).and(be_frozen)
-    end
-
-    it 'is expected to memoize the Support instance' do
-      first_call = described_class.support
-      second_call = described_class.support
-
-      expect(first_call).to be(second_call)
+      expect(support).to eq(Sai::Support)
     end
   end
 


### PR DESCRIPTION
## Description:

This introduces the ability to explicitly control terminal color modes in Sai. Users can now choose specific color modes or set maximum color levels with automatic downgrading.

### Key Feature: Color Mode Selection

```ruby
# Choose specific color modes
puts Sai.with_mode(Sai.mode.true_color).red.decorate('Force 24-bit color')
puts Sai.with_mode(Sai.mode.advanced).red.decorate('Force 256 colors')
puts Sai.with_mode(Sai.mode.ansi).red.decorate('Force 16 colors')
puts Sai.with_mode(Sai.mode.basic).red.decorate('8 colors')
puts Sai.with_mode(Sai.mode.no_color).red.decorate('Disable colors')

# Set maximum modes with automatic downgrading
puts Sai.with_mode(Sai.mode.advanced_auto).red.decorate('256 colors or less')
puts Sai.with_mode(Sai.mode.ansi_auto).red.decorate('16 colors or less')
puts Sai.with_mode(Sai.mode.basic_auto).red.decorate('8 colors or less')

# Create reusable decorators with specific modes
class CLI
  ERROR = Sai.with_mode(Sai.mode.basic_auto).red.bold
  SUCCESS = Sai.with_mode(Sai.mode.advanced_auto).green
end
```

### Additional Changes

* Renamed `bit8?` to `advanced?` for clearer terminal capability naming
* Changed `Support` from class to module for better API design
* Updated documentation with examples and warnings about color mode behavior

### Migration Note

The `bit8?` terminal capability check has been renamed to `advanced?` for better clarity. 
Users should update their code to use the new method name:

```ruby
# Old
terminal.bit8? 

# New 
terminal.advanced?
```

## Changelog
- added mode selection via new `ModeSelector` module
- changed `bit8?` to `advanced?` in terminal capability detection
- changed `Support` from class to module for improved API design
- changed `BIT8` to `ADVANCED` in `ColorMode` constants
- changed `decorator` to accept optional `mode:` parameter
- updated documentation with color mode examples and warnings