### PR TITLE
Add SequencedString for ANSI string manipulation and change Decorator#decorate return type

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -8,4 +8,4 @@ lib/**/*.rb
 --embed-mixins
 --tag rbs
 --hide-tag rbs
---files LICENSE
+--files LICENSE,docs/USAGE.md

--- a/README.md
+++ b/README.md
@@ -4,35 +4,36 @@
 [![Sai Codacy grade](https://img.shields.io/codacy/grade/0f9a91b573ed4768a773867b95ed4894/main?style=for-the-badge&logo=codacy&logoColor=white&logoSize=auto)](https://app.codacy.com/gh/aaronmallen/sai)
 [![Sai Codacy coverage](https://img.shields.io/codacy/coverage/0f9a91b573ed4768a773867b95ed4894/main?style=for-the-badge&logo=codacy&logoColor=white&logoSize=auto)](https://app.codacy.com/gh/aaronmallen/sai/coverage)
 [![Sai License](https://img.shields.io/github/license/aaronmallen/sai?style=for-the-badge&logo=opensourceinitiative&logoColor=white&logoSize=auto)](./LICENSE)
-[![Sai Docs](https://img.shields.io/badge/rubydoc-blue?style=for-the-badge&logo=readthedocs&logoColor=white&logoSize=auto&label=docs)](https://rubydoc.info/gems/sai/0.2.0)
+[![Sai Docs](https://img.shields.io/badge/rubydoc-blue?style=for-the-badge&logo=readthedocs&logoColor=white&logoSize=auto&label=docs)](https://rubydoc.info/gems/sai/0.3.0)
 [![Sai Open Issues](https://img.shields.io/github/issues-search/aaronmallen/sai?query=state%3Aopen&style=for-the-badge&logo=github&logoColor=white&logoSize=auto&label=issues&color=red)](https://github.com/aaronmallen/sai/issues?q=state%3Aopen%20)
 
 An elegant color management system for crafting sophisticated CLI applications
 
 ```ruby
-puts Sai.rgb(255, 128, 0).bold.decorate('Create beautiful CLI applications')
-puts Sai.hex('#4834d4').italic.decorate('with intuitive color management')
-puts Sai.bright_cyan.on_blue.underline.decorate('that adapts to any terminal')
+# Create beautiful CLI applications with intuitive color management
+puts Sai.rgb(255, 128, 0).bold.decorate('Warning: Battery Low')
+puts Sai.hex('#4834d4').italic.decorate('Processing request...')
+puts Sai.bright_cyan.on_blue.underline.decorate('Download Complete!')
+
+# Analyze and manipulate ANSI-encoded text
+text = Sai.sequence("\e[31mError:\e[0m Connection failed")
+puts text.without_color  # Keep formatting, remove colors
+puts text.stripped      # Get plain text without any formatting
 ```
 
 Sai (彩) - meaning 'coloring' or 'paint' in Japanese - is a powerful and intuitive system for managing color output in
 command-line applications. Drawing inspiration from traditional Japanese artistic techniques, Sai brings vibrancy and
 harmony to terminal interfaces through its sophisticated color management.
 
-Sai empowers developers to create beautiful, colorful CLI applications that maintain visual consistency across different
-terminal capabilities. Like its artistic namesake, it combines simplicity and sophistication to bring rich, adaptive
-color to your terminal interfaces.
-
 ## Features
 
-* Automatic color mode detection and downgrading
-* Support for True Color (24-bit), 256 colors (8-bit), ANSI colors (4-bit), and basic colors (3-bit)
-* Rich set of ANSI text styles
-* Named color support with bright variants
-* RGB and Hex color support
-* Foreground and background colors
+* Rich color support (True Color, 256 colors, ANSI, and basic modes)
+* Automatic terminal capability detection and color mode adaptation
+* RGB, Hex, and named color support with bright variants
+* Comprehensive text styling (bold, italic, underline, etc.)
+* Advanced ANSI sequence parsing and manipulation
+* Intelligent color downgrading for compatibility
 * Respects NO_COLOR environment variable
-* Can be used directly or included in classes/modules
 
 ## Installation
 
@@ -44,20 +45,20 @@ gem 'sai'
 
 Or install it yourself as:
 
-```bash
+```ruby
 gem install sai
 ```
 
-## Usage
+> [!IMPORTANT]  
+> If you're upgrading from version 0.2.0, please see our [Migration Guide](docs/migrations/0.2.0-to-0.3.0.md) for
+> important changes.
 
-Sai can be used directly or included in your own classes and modules.
-
-### Direct Usage
+## Quick Start
 
 ```ruby
 require 'sai'
 
-# Using named colors
+# Basic usage
 puts Sai.red.decorate('Error!')
 puts Sai.bright_blue.on_white.decorate('Info')
 
@@ -65,234 +66,21 @@ puts Sai.bright_blue.on_white.decorate('Info')
 puts Sai.rgb(255, 128, 0).decorate('Custom color')
 puts Sai.on_rgb(0, 255, 128).decorate('Custom background')
 
-# Using hex colors
-puts Sai.hex('#FF8000').decorate('Hex color')
-puts Sai.on_hex('#00FF80').decorate('Hex background')
-
 # Applying styles
 puts Sai.bold.underline.decorate('Important')
 puts Sai.red.bold.italic.decorate('Error!')
 
-# Complex combinations
-puts Sai.bright_cyan
-        .on_blue
-        .bold
-        .italic
-        .decorate('Styled text')
+# Working with ANSI sequences
+text = Sai.sequence("\e[31mError:\e[0m Details here")
+puts text.without_color    # Remove colors but keep formatting
+puts text.without_style    # Remove formatting but keep colors
+puts text.stripped        # Get plain text
 ```
 
-### Module Inclusion
+## Documentation
 
-```ruby
-class CLI
-  include Sai
-
-  def error(message)
-    puts decorator.red.bold.decorate(message)
-  end
-
-  def info(message)
-    puts decorator.bright_blue.decorate(message)
-  end
-
-  def success(message)
-    puts decorator.with_mode(color_mode.ansi_auto).green.decorate(message)
-  end
-end
-
-cli = CLI.new
-cli.error('Something went wrong!')
-cli.info('Processing...')
-cli.success('Done!')
-```
-
-### Defining Reusable Styles
-
-Sai decorators can be assigned to constants to create reusable styles throughout your application:
-
-```ruby
-module Style
-  ERROR = Sai.bold.bright_white.on_red
-  WARNING = Sai.black.on_yellow
-  SUCCESS = Sai.bright_green
-  INFO = Sai.bright_blue
-  HEADER = Sai.bold.bright_cyan.underline
-end
-
-# Use your defined styles
-puts Style::ERROR.decorate('Something went wrong!')
-puts Style::SUCCESS.decorate('Operation completed successfully')
-
-# Styles can be further customized when needed
-puts Style::ERROR.italic.decorate('Critical error!')
-```
-
-> [!TIP]
-> This pattern is particularly useful for maintaining consistent styling across your application and creating theme
-> systems. You can even build on existing styles:
->
-> ```ruby
-> module Theme
->   PRIMARY = Sai.rgb(63, 81, 181)
->   SECONDARY = Sai.rgb(255, 87, 34)
->
->   BUTTON = PRIMARY.bold
->   LINK = SECONDARY.underline
->   HEADER = PRIMARY.bold.underline
-> end
-> ```
-
-## Features
-
-### Color Support
-
-Sai supports up to 16.7 million colors (true color/24-bit) depending on your terminal's capabilities. Colors can be
-specified in several ways:
-
-#### RGB Colors
-
-```ruby
-# Specify any RGB color (0-255 per channel)
-Sai.rgb(255, 128, 0).decorate('Orange text')
-Sai.on_rgb(0, 255, 128).decorate('Custom green background')
-```
-
-#### Hex Colors
-
-```ruby
-# Use any hex color code
-Sai.hex('#FF8000').decorate('Orange text')
-Sai.on_hex('#00FF80').decorate('Custom green background')
-```
-
-#### Named Color Shortcuts
-
-For convenience, Sai provides shortcuts for common ANSI colors:
-
-Standard colors:
-
-```ruby
-Sai.red.decorate('Red text')
-Sai.blue.decorate('Blue text')
-Sai.on_green.decorate('Green background')
-```
-
-Bright variants:
-
-```ruby
-Sai.bright_red.decorate('Bright red text')
-Sai.bright_blue.decorate('Bright blue text')
-Sai.on_bright_green.decorate('Bright green background')
-```
-
-Available named colors:
-
-* black/bright_black
-* red/bright_red
-* green/bright_green
-* yellow/bright_yellow
-* blue/bright_blue
-* magenta/bright_magenta
-* cyan/bright_cyan
-* white/bright_white
-
-> [!TIP]
-> While named colors provide convenient shortcuts, remember that Sai supports the full RGB color space. Don't feel
-> limited to just these predefined colors!
-
-### Text Styles
-
-Available styles:
-
-* bold
-* dim
-* italic
-* underline
-* blink
-* rapid_blink
-* reverse
-* conceal
-* strike
-
-Style removal:
-
-* no_blink
-* no_italic
-* no_underline
-* no_reverse
-* no_conceal
-* no_strike
-* normal_intensity
-
-### Color Mode Detection & Downgrading
-
-Sai automatically detects your terminal's color capabilities and adapts the output appropriately:
-
-* True Color terminals (24-bit): Full access to all 16.7 million colors
-* 256-color terminals (8-bit): Colors are mapped to the closest available color in the 256-color palette
-* ANSI terminals (4-bit): Colors are mapped to the 16 standard ANSI colors
-* Basic terminals (3-bit): Colors are mapped to the 8 basic ANSI colors
-* NO_COLOR: All color sequences are stripped when the NO_COLOR environment variable is set
-
-> [!NOTE]
-> This automatic downgrading ensures your application looks great across all terminal types without any extra code!
-
-### Color Mode Selection
-
-Sai provides flexible color mode selection through its `mode` interface:
-
-```ruby
-# Use automatic mode detection (default)
-Sai.with_mode(Sai.mode.auto)
-
-# Force specific color modes
-puts Sai.with_mode(Sai.mode.true_color).red.decorate('24-bit color')
-puts Sai.with_mode(Sai.mode.advanced).red.decorate('256 colors')
-puts Sai.with_mode(Sai.mode.ansi).red.decorate('16 colors')
-puts Sai.with_mode(Sai.mode.basic).red.decorate('8 colors')
-puts Sai.with_mode(Sai.mode.no_color).red.decorate('No color')
-
-# Use automatic downgrading
-puts Sai.with_mode(Sai.mode.advanced_auto).red.decorate('256 colors or less')
-puts Sai.with_mode(Sai.mode.ansi_auto).red.decorate('16 colors or less')
-puts Sai.with_mode(Sai.mode.basic_auto).red.decorate('8 colors or less')
-```
-
-> [!WARNING]
-> When using fixed color modes (like `true_color` or `advanced`), Sai will not automatically downgrade colors for
-> terminals with lower color support. For automatic color mode adjustment, use modes ending in `_auto`
-> (like `advanced_auto` or `ansi_auto`).
-
-This allows you to:
-
-* Explicitly set specific color modes
-* Use automatic mode detection (default)
-* Set maximum color modes with automatic downgrading
-* Disable colors entirely
-
-### Terminal Support Detection
-
-You can check the terminal's capabilities:
-
-```ruby
-# Using directly
-Sai.support.true_color? # => true/false
-Sai.support.advanced?   # => true/false
-Sai.support.ansi?      # => true/false
-Sai.support.basic?     # => true/false
-Sai.support.color?     # => true/false
-
-# Using included module
-class CLI
-  include Sai
-
-  def check_support
-    if terminal_color_support.true_color?
-      puts "Terminal supports true color!"
-    end
-  end
-end
-```
+* [Complete Usage Guide](docs/USAGE.md) - Comprehensive documentation of all features
+* [API Documentation](https://rubydoc.info/gems/sai/0.3.0) - Detailed API reference
 
 ## Contributing
 

--- a/Steepfile
+++ b/Steepfile
@@ -36,4 +36,10 @@
 target :lib do
   signature 'sig'
   check 'lib'
+
+  library 'strscan'
+
+  configure_code_diagnostics do |hash|
+    hash[Steep::Diagnostic::Ruby::UnannotatedEmptyCollection] = :information
+  end
 end

--- a/Steepfile
+++ b/Steepfile
@@ -37,6 +37,7 @@ target :lib do
   signature 'sig'
   check 'lib'
 
+  library 'forwardable'
   library 'strscan'
 
   configure_code_diagnostics do |hash|

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,64 +1,116 @@
 # Contributing to Sai
 
-First off, thank you for your interest in Sai! As this project is in early active development, we're currently focused
-on stabilizing the core functionality and architecture. During this phase, we're primarily seeking bug reports rather
-than code contributions.
+First off, thank you for considering contributing to Sai! It's people like you who make Sai such a great tool.
 
-## Current Development Status
+## Code of Conduct
 
-Kōshi is under active development, and many core features are still being designed and implemented. The API and internal
-architecture may undergo significant changes. As such, we're being selective about external contributions to maintain
-development velocity and architectural consistency.
+This project and everyone participating in it is governed by our [Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.
 
-## How to Contribute
+## How Can I Contribute?
 
-### Bug Reports
+### Reporting Bugs
 
-Bug reports are highly valuable to us during this phase. If you encounter any issues, please submit them via GitHub
-Issues. When submitting a bug report, please include:
+When filing a bug report, please include:
 
 1. **Ruby Version**: The version of Ruby you're using
-2. **Kōshi Version**: The version of Kōshi where you encountered the issue
+2. **Sai Version**: The version of Sai where you encountered the issue
 3. **Terminal Environment**: Your terminal emulator and operating system
 4. **Description**: A clear description of what happened versus what you expected
 5. **Reproduction Steps**: Detailed steps to reproduce the issue
 6. **Code Sample**: A minimal code example that demonstrates the issue
 7. **Terminal Output**: Any relevant error messages or unexpected output
-8. **Screenshots**: If applicable, screenshots showing the issue (especially for layout-related bugs)
+8. **Screenshots**: If applicable, screenshots showing the issue (especially for color-related bugs)
 
-### Feature Requests
+### Suggesting Enhancements
 
-While we're focused on core development, we welcome feature suggestions via GitHub Issues. Please note that feature
-requests may be deferred until after the initial stable release.
+Enhancement suggestions are welcome! When suggesting an enhancement, please:
 
-### Code Contributions
+* **Check Existing Issues**: Make sure a similar suggestion hasn't already been made
+* **Provide Context**: Explain why this enhancement would be useful
+* **Consider Scope**: Describe if this is a general enhancement or specific to certain use cases
+* **Include Examples**: If possible, provide example code or mockups
 
-At this time, we are not accepting pull requests for new features or significant changes. This policy will be revised as
-the project matures. However, we may accept small fixes for critical bugs - please open an issue first to discuss.
+### Pull Requests
 
-## Development Roadmap
+#### Getting Started
 
-Our current focus is on:
-- Stabilizing the core grid layout engine
-- Implementing basic theming capabilities
-- Establishing a consistent, intuitive API
-- Comprehensive testing across different terminal environments
+1. Fork the repository
+2. Clone your fork: `git clone https://github.com/your-username/sai.git`
+3. Create a branch: `git checkout -b my-feature-branch`
 
-## Questions and Discussions
+#### Development Process
 
-If you have questions about using Sai or want to discuss its development:
-- Open a [GitHub Discussion](https://github.com/aaronmallen/sai/discussions) for general questions
-- Join our [Discord server](link-to-discord) for real-time discussions
-- Check the [documentation](link-to-docs) for guides and API reference
+1. Run `bin/setup` to install dependencies
+2. Make your changes
+3. Add tests for your changes
+4. Run the CI checks locally:
+   ```bash
+   bundle exec rubocop -A && \
+   COVERAGE=true bundle exec rspec && \
+   RUBYOPT='-r bundler/setup -r rbs/test/setup' \
+   RBS_TEST_TARGET=Sai::* \
+   RBS_TEST_LOG_LEVEL=error \
+   RBS_TEST_DOUBLE_SUITE=rspec \
+   RBS_TEST_OPT='-I sig' \
+   bundle exec rspec --tag ~rbs:skip && \
+   bundle exec steep check
+   ```
 
-## Code of Conduct
+#### Code Style
 
-Please note that this project follows a [Code of Conduct](CODE_OF_CONDUCT.md). By participating in this project, you
-agree to abide by its terms.
+We follow a specific code style as defined in our RuboCop configuration:
 
-## Future Contributions
+* Methods should be organized by class/instance and visibility
+* Documentation should follow YARD format with required tags
+* Tests should follow our RSpec guidelines (see Testing section)
 
-Once we reach a more stable state, we'll update this guide with more comprehensive contribution guidelines. Follow the
-project or watch for announcements about when we'll begin accepting more types of contributions.
+#### Testing Requirements
 
-Thank you for your understanding and support as we work to build a solid foundation for Kōshi!
+Please make sure your changes include appropriate tests:
+
+* New features should include unit tests
+* Bug fixes should include regression tests
+* Tests should be clear and maintainable
+
+#### Documentation
+
+Documentation is crucial! Please:
+
+* Add YARD documentation for new methods/classes
+* Update the README.md if necessary
+* Add examples showing how to use new features
+* Update the USAGE.md guide for significant changes
+
+#### Pull Request Process
+
+1. Ensure all CI checks pass
+2. Get review from maintainers
+3. Respond to feedback and make requested changes
+4. Once approved, maintainers will merge your PR
+
+## Development Environment
+
+### Setting Up
+
+1. Install Ruby (see .ruby-version for current version)
+2. Clone the repository
+3. Run `bin/setup`
+4. Run the CI script to verify setup
+
+### Running Tests
+
+* Full CI check: Use the CI script above
+* Just RSpec: `bundle exec rspec`
+* Specific tests: `bundle exec rspec spec/path/to/file_spec.rb`
+* RuboCop: `bundle exec rubocop` or `bundle exec rubocop -A` for auto-correct
+* Type checking: `bundle exec steep check`
+
+## Getting Help
+
+If you need help, you can:
+
+* Open a [GitHub Discussion](https://github.com/aaronmallen/sai/discussions) for general questions
+* Check the [documentation](https://rubydoc.info/gems/sai) for guides and API reference
+* Join our community (link to be added)
+
+Thank you again for contributing to Sai!

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,0 +1,303 @@
+# Sai Usage Guide
+
+This guide provides comprehensive documentation for using Sai in your applications.
+
+## Table of Contents
+
+* [Basic Usage](#basic-usage)
+* [Color Support](#color-support)
+  * [RGB Colors](#rgb-colors)
+  * [Hex Colors](#hex-colors)
+  * [Named Colors](#named-colors)
+* [Text Styles](#text-styles)
+* [ANSI Sequence Manipulation](#ansi-sequence-manipulation)
+* [Color Mode Management](#color-mode-management)
+* [Terminal Capabilities](#terminal-capabilities)
+* [Integration Patterns](#integration-patterns)
+* [Best Practices](#best-practices)
+
+## Basic Usage
+
+Sai can be used directly or included in your own classes and modules:
+
+```ruby
+# Direct usage
+puts Sai.red.decorate('Error!')
+puts Sai.bright_blue.on_white.decorate('Info')
+
+# Include in your own classes
+class CLI
+  include Sai
+
+  def error(message)
+    puts decorator.red.bold.decorate(message)
+  end
+
+  def info(message)
+    puts decorator.bright_blue.decorate(message)
+  end
+end
+```
+
+## Color Support
+
+### RGB Colors
+
+Use any RGB color (0-255 per channel):
+
+```ruby
+# Foreground colors
+Sai.rgb(255, 128, 0).decorate('Orange text')
+Sai.rgb(100, 149, 237).decorate('Cornflower blue')
+
+# Background colors
+Sai.on_rgb(0, 255, 128).decorate('Custom green background')
+```
+
+### Hex Colors
+
+Use any hex color code:
+
+```ruby
+# Foreground colors
+Sai.hex('#FF8000').decorate('Orange text')
+Sai.hex('#6495ED').decorate('Cornflower blue')
+
+# Background colors
+Sai.on_hex('#00FF80').decorate('Custom green background')
+```
+
+### Named Colors
+
+Common ANSI colors have convenient shortcuts:
+
+```ruby
+# Standard colors
+Sai.red.decorate('Red text')
+Sai.blue.decorate('Blue text')
+Sai.on_green.decorate('Green background')
+
+# Bright variants
+Sai.bright_red.decorate('Bright red text')
+Sai.bright_blue.decorate('Bright blue text')
+Sai.on_bright_green.decorate('Bright green background')
+```
+
+Available named colors:
+* black/bright_black
+* red/bright_red
+* green/bright_green
+* yellow/bright_yellow
+* blue/bright_blue
+* magenta/bright_magenta
+* cyan/bright_cyan
+* white/bright_white
+
+> [!TIP]
+> While named colors provide convenient shortcuts, remember that Sai supports the full RGB color space. Don't feel
+> limited to just these predefined colors!
+
+## Text Styles
+
+Sai supports a variety of text styles:
+
+```ruby
+Sai.bold.decorate('Bold text')
+Sai.italic.decorate('Italic text')
+Sai.underline.decorate('Underlined text')
+Sai.strike.decorate('Strikethrough text')
+```
+
+Available styles:
+* bold
+* dim
+* italic
+* underline
+* blink
+* rapid_blink
+* reverse
+* conceal
+* strike
+
+Style removal:
+* no_blink
+* no_italic
+* no_underline
+* no_reverse
+* no_conceal
+* no_strike
+* normal_intensity
+
+## ANSI Sequence Manipulation
+
+Sai provides powerful tools for working with ANSI-encoded strings:
+
+```ruby
+# Create a SequencedString from decorated text
+text = Sai.red.bold.decorate("Warning!")
+
+# Or parse existing ANSI text
+text = Sai.sequence("\e[31mred\e[0m and \e[32mgreen\e[0m")
+
+# Get plain text without formatting
+plain = text.stripped  # => "red and green"
+
+# Remove specific attributes
+text.without_color    # Remove all colors but keep styles
+text.without_style    # Remove all styles but keep colors
+text.without_style(:bold, :italic)  # Remove specific styles
+
+# Access individual segments
+text.each do |segment|
+  puts "Text: #{segment.text}"
+  puts "Foreground: #{segment.foreground}"
+  puts "Background: #{segment.background}"
+  puts "Styles: #{segment.styles}"
+  puts "Position: #{segment.encoded_location.start_position}..#{segment.encoded_location.end_position}"
+end
+```
+
+## Color Mode Management
+
+Sai by default automatically detects your terminal's capabilities and automatically downgrades colors based on those
+capabilities but also allows manual control:
+
+```ruby
+# Use automatic mode detection (default)
+Sai.with_mode(Sai.mode.auto)
+
+# Force specific color modes
+puts Sai.with_mode(Sai.mode.true_color).red.decorate('24-bit color')
+puts Sai.with_mode(Sai.mode.advanced).red.decorate('256 colors')
+puts Sai.with_mode(Sai.mode.ansi).red.decorate('16 colors')
+puts Sai.with_mode(Sai.mode.basic).red.decorate('8 colors')
+puts Sai.with_mode(Sai.mode.no_color).red.decorate('No color')
+
+# Use automatic downgrading
+puts Sai.with_mode(Sai.mode.advanced_auto).red.decorate('256 colors or less')
+puts Sai.with_mode(Sai.mode.ansi_auto).red.decorate('16 colors or less')
+puts Sai.with_mode(Sai.mode.basic_auto).red.decorate('8 colors or less')
+```
+
+> [!WARNING]
+> When using fixed color modes (like `true_color` or `advanced`), Sai will not automatically downgrade colors for
+> terminals with lower color support. For automatic color mode adjustment, use modes ending in `_auto`
+> (like `advanced_auto` or `ansi_auto`).
+
+Color Mode Hierarchy:
+
+1. True Color (24-bit): 16.7 million colors
+2. Advanced (8-bit): 256 colors
+3. ANSI (4-bit): 16 colors
+4. Basic (3-bit): 8 colors
+5. No Color: All formatting stripped
+
+## Terminal Capabilities
+
+Check terminal color support:
+
+```ruby
+# Using directly
+Sai.support.true_color? # => true/false
+Sai.support.advanced?   # => true/false
+Sai.support.ansi?      # => true/false
+Sai.support.basic?     # => true/false
+Sai.support.color?     # => true/false
+
+# Using included module
+class CLI
+  include Sai
+
+  def check_support
+    if terminal_color_support.true_color?
+      puts "Terminal supports true color!"
+    end
+  end
+end
+```
+
+## Integration Patterns
+
+### Defining Reusable Styles
+
+Create consistent styling across your application:
+
+```ruby
+module Style
+  ERROR = Sai.bold.bright_white.on_red
+  WARNING = Sai.black.on_yellow
+  SUCCESS = Sai.bright_green
+  INFO = Sai.bright_blue
+  HEADER = Sai.bold.bright_cyan.underline
+end
+
+# Use your defined styles
+puts Style::ERROR.decorate('Something went wrong!')
+puts Style::SUCCESS.decorate('Operation completed successfully')
+
+# Styles can be further customized
+puts Style::ERROR.italic.decorate('Critical error!')
+```
+
+> [!TIP]
+> This pattern is particularly useful for maintaining consistent styling across your application and creating theme
+> systems. You can even build on existing styles:
+>
+> ```ruby
+> module Theme
+>   PRIMARY = Sai.rgb(63, 81, 181)
+>   SECONDARY = Sai.rgb(255, 87, 34)
+>
+>   BUTTON = PRIMARY.bold
+>   LINK = SECONDARY.underline
+>   HEADER = PRIMARY.bold.underline
+> end
+> ```
+
+### Class Integration
+
+Integrate Sai into your classes:
+
+```ruby
+class Logger
+  include Sai
+
+  def error(message)
+    puts decorator.red.bold.decorate(message)
+  end
+
+  def warn(message)
+    puts decorator.yellow.decorate(message)
+  end
+
+  def info(message)
+    puts decorator.with_mode(color_mode.true_color).bright_blue.decorate(message)
+  end
+end
+```
+
+## Best Practices
+
+1. **Automatic Mode Detection**
+  * Use `Sai.mode.auto` by default to respect terminal capabilities
+  * Only force specific color modes when necessary
+
+2. **Color Usage**
+  * Use named colors for standard indicators (red for errors, etc.)
+  * Use RGB/Hex for brand colors or specific design requirements
+  * Consider color blindness when choosing colors
+
+3. **Style Organization**
+  * Create reusable styles for consistency
+  * Group related styles in modules
+  * Consider creating a theme system for larger applications
+
+4. **Performance**
+  * Cache decorator instances when using repeatedly
+  * Use `SequencedString` parsing for complex manipulations
+  * Consider terminal capabilities when designing output
+
+5. **Accessibility**
+  * Don't rely solely on color for important information
+  * Use styles (bold, underline) to enhance meaning
+  * Respect NO_COLOR environment variable

--- a/docs/migrations/0.2.0-0.3.0.md
+++ b/docs/migrations/0.2.0-0.3.0.md
@@ -1,0 +1,126 @@
+# Migrating from Sai v0.2.0 to v0.3.0
+
+## Breaking Changes
+
+### Decorator#decorate Return Type
+
+The `decorate` method (and its aliases `apply`, `call`, and `encode`) now return a `Sai::ANSI::SequencedString`
+instance instead of a raw string. While the `SequencedString` class implements `to_s` and `to_str` for string
+compatibility, some string operations might need explicit conversion:
+
+```ruby
+# 0.2.0
+text = Sai.red.decorate("Hello")  # => String
+text.gsub("H", "h")               # works directly
+
+# 0.3.0
+text = Sai.red.decorate("Hello")  # => Sai::ANSI::SequencedString
+text.to_s.gsub("H", "h")         # need explicit conversion
+```
+
+## New Features
+
+### SequencedString Class
+
+The new `Sai::ANSI::SequencedString` class provides powerful capabilities for working with ANSI-encoded strings:
+
+```ruby
+# Create a SequencedString
+string = Sai.sequence("\e[31mred\e[0m and \e[32mgreen\e[0m")
+
+# Access individual segments
+string[0].text         # => "red"
+string[0].foreground   # => "31"
+
+# Strip ANSI sequences
+string.stripped        # => "red and green"
+
+# Remove specific attributes
+string.without_color   # removes foreground/background colors
+string.without_style   # removes styling (bold, italic, etc.)
+string.without_background  # removes only background colors
+string.without_foreground # removes only foreground colors
+
+# Remove specific styles
+string.without_style(:bold, :italic)
+```
+
+### Sai.sequence Method
+
+A new `sequence` method has been added to create `SequencedString` instances directly:
+
+```ruby
+# Parse existing ANSI-encoded text
+text = Sai.sequence("\e[31mHello\e[0m")
+
+# Examine the structure
+text.each do |segment|
+  puts "Text: #{segment.text}"
+  puts "Foreground: #{segment.foreground}"
+  puts "Background: #{segment.background}"
+  puts "Styles: #{segment.styles}"
+end
+```
+
+## Examples
+
+### Working with Decorated Text
+
+```ruby
+# Create decorated text
+text = Sai.red.bold.decorate("Warning!")
+
+# Get plain text without any formatting
+plain = text.stripped  # => "Warning!"
+
+# Remove just the color but keep styling
+styled = text.without_color  # => "\e[1mWarning!\e[0m"
+
+# Remove specific styles
+colored = text.without_style(:bold)  # => "\e[31mWarning!\e[0m"
+```
+
+### Analyzing ANSI Sequences
+
+```ruby
+# Parse complex ANSI text
+text = Sai.sequence("\e[31;1mBold Red\e[0m \e[32mGreen\e[0m")
+
+# Examine each segment
+text.each do |segment|
+  puts "Segment: #{segment.text}"
+  puts "Location: #{segment.encoded_location.start_position}..#{segment.encoded_location.end_position}"
+  puts "Stripped Location: #{segment.stripped_location.start_position}..#{segment.stripped_location.end_position}"
+  puts "---"
+end
+```
+
+## Best Practices
+
+1. Use `to_s` explicitly when you need string operations on decorated text
+2. Take advantage of the new `SequencedString` capabilities for more sophisticated text processing
+3. Use the new `sequence` method when you need to analyze or manipulate existing ANSI-encoded text
+4. Consider using `stripped` instead of manual ANSI sequence stripping
+5. Use specific removal methods (`without_color`, `without_style`, etc.) instead of manual sequence manipulation
+
+## Compatibility Notes
+
+1. The `SequencedString` class implements `to_s` and `to_str` for backward compatibility
+2. Most string operations will work through Ruby's implicit conversion
+3. `puts` and other IO operations work normally with `SequencedString` - no changes needed
+4. For maximum compatibility with other string operations, explicitly convert to string when needed
+
+```ruby
+# These all work the same as before:
+puts Sai.red.decorate("Hello")
+print Sai.blue.decorate("World")
+$stderr.puts Sai.yellow.decorate("Warning")
+
+# The SequencedString is automatically converted to a properly formatted string
+```
+
+## Additional Resources
+
+* [Full Documentation](https://rubydoc.info/gems/sai/0.3.0)
+* [GitHub Repository](https://github.com/aaronmallen/sai)
+* [Issue Tracker](https://github.com/aaronmallen/sai/issues)

--- a/lib/sai.rb
+++ b/lib/sai.rb
@@ -125,6 +125,24 @@ module Sai
     #   def white: () -> Decorator
     #   def yellow: () -> Decorator
 
+    # Sequence a string with ANSI escape codes
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api public
+    #
+    # @example Sequence a string with ANSI escape codes
+    #   Sai.sequence("\e[38;2;205;0;0mHello, World!\e[0m") #=> #<Sai::ANSI::SequencedString:0x123>
+    #
+    # @param text [String] the text to sequence
+    #
+    # @return [ANSI::SequencedString] the sequenced string
+    # @rbs (String text) -> ANSI::SequencedString
+    def sequence(text)
+      ANSI::SequencedString.new(text)
+    end
+
     # The supported color modes for the terminal
     #
     # @author {https://aaronmallen.me Aaron Allen}

--- a/lib/sai.rb
+++ b/lib/sai.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'sai/ansi'
+require 'sai/ansi/sequence_processor'
 require 'sai/conversion/color_sequence'
 require 'sai/conversion/rgb'
 require 'sai/decorator'

--- a/lib/sai.rb
+++ b/lib/sai.rb
@@ -2,6 +2,7 @@
 
 require 'sai/ansi'
 require 'sai/ansi/sequence_processor'
+require 'sai/ansi/sequenced_string'
 require 'sai/conversion/color_sequence'
 require 'sai/conversion/rgb'
 require 'sai/decorator'

--- a/lib/sai/ansi/sequence_processor.rb
+++ b/lib/sai/ansi/sequence_processor.rb
@@ -1,0 +1,380 @@
+# frozen_string_literal: true
+
+require 'sai/ansi'
+require 'strscan'
+
+module Sai
+  module ANSI
+    # Extract ANSI sequence information from a string
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api private
+    class SequenceProcessor # rubocop:disable Metrics/ClassLength
+      # The pattern to extract ANSI sequences from a string
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @return [Regexp] the pattern
+      SEQUENCE_PATTERN = /\e\[([0-9;]*)m/ #: Regexp
+      private_constant :SEQUENCE_PATTERN
+
+      # Matches the code portion of style sequences
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @return [Regexp] the pattern
+      STYLE_CODE_PATTERN = /(?:[1-9]|2[1-9])/ #: Regexp
+      private_constant :STYLE_CODE_PATTERN
+
+      # Initialize a new instance of SequenceProcessor and parse the provided string
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @param string [String] the string to parse
+      #
+      # @return [Array<Hash{Symbol => Object}>] the segments
+      # @rbs (String string) -> Array[Hash[Symbol, untyped]]
+      def self.process(string)
+        new(string).process
+      end
+
+      # Initialize a new instance of SequenceProcessor
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @param string [String] the string to parse
+      #
+      # @return [SequenceProcessor] the new instance of SequenceProcessor
+      # @rbs (String string) -> void
+      def initialize(string)
+        @scanner         = StringScanner.new(string)
+        @segments        = [] #: Array[Hash[Symbol, untyped]]
+        @current_segment = blank_segment
+        @encoded_pos     = 0
+        @stripped_pos    = 0
+      end
+
+      # Parse a string and return a hash of segments
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @return [Array<Hash{Symbol => Object}>] the segments
+      # @rbs () -> Array[Hash[Symbol, untyped]]
+      def process
+        consume_tokens
+        finalize_segment_if_text!
+
+        @segments
+      end
+
+      private
+
+      # Applies 24-bit truecolor (e.g., 38;2;R;G;B or 48;2;R;G;B)
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @param codes_array [Array<Integer>]
+      # @param index [Integer]
+      #
+      # @return [Integer] the updated index (consumed 5 codes)
+      # @rbs (Array[Integer] codes_array, Integer index) -> Integer
+      def apply_24bit_color(codes_array, index)
+        base_code = codes_array[index]
+        r = codes_array[index + 2]
+        g = codes_array[index + 3]
+        b = codes_array[index + 4]
+
+        if base_code == 38
+          @current_segment[:foreground] = "38;2;#{r};#{g};#{b}"
+        else
+          @current_segment[:background] = "48;2;#{r};#{g};#{b}"
+        end
+        index + 5
+      end
+
+      # Applies 256-color mode (e.g., 38;5;160 or 48;5;21)
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @param codes_array [Array<Integer>]
+      # @param index [Integer]
+      #
+      # @return [Integer] the updated index (consumed 3 codes)
+      # @rbs (Array[Integer] codes_array, Integer index) -> Integer
+      def apply_256_color(codes_array, index)
+        base_code = codes_array[index]
+        color_number = codes_array[index + 2]
+        if base_code == 38
+          @current_segment[:foreground] = "38;5;#{color_number}"
+        else
+          @current_segment[:background] = "48;5;#{color_number}"
+        end
+        index + 3 # consumed 3 codes total
+      end
+
+      # Applies the appropriate action for the provided ANSI sequence
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @param sequence [String] an ANSI sequence (e.g. "\e[31m", "\e[0m")
+      #
+      # @return [void]
+      # @rbs (String sequence) -> void
+      def apply_ansi_sequence(sequence)
+        return reset_segment! if sequence == ANSI::RESET
+
+        codes = sequence.match(SEQUENCE_PATTERN)&.[](1)
+        return unless codes
+
+        apply_codes(codes)
+      end
+
+      # Applies a basic color (FG or BG) in the range 30..37 (FG) or 40..47 (BG)
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @param code [Integer] the numeric color code
+      #
+      # @return [void]
+      # @rbs (Integer code) -> void
+      def apply_basic_color(code)
+        if (30..37).cover?(code)
+          @current_segment[:foreground] = code.to_s
+        else # 40..47
+          @current_segment[:background] = code.to_s
+        end
+      end
+
+      # Parse all numeric codes in the provided string, applying them in order (just like a real ANSI terminal)
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @param codes_string [String] e.g. "38;5;160;48;5;21;1"
+      #
+      # @return [void]
+      # @rbs (String codes_string) -> void
+      def apply_codes(codes_string)
+        codes_array = codes_string.split(';').map(&:to_i)
+        i = 0
+        i = apply_single_code(codes_array, i) while i < codes_array.size
+      end
+
+      # Applies a single code (or group) from the array. This might be:
+      #  - 0 => reset
+      #  - 30..37 => basic FG color
+      #  - 40..47 => basic BG color
+      #  - 38 or 48 => extended color sequence
+      #  - otherwise => style code (bold, underline, etc.)
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @param codes_array [Array<Integer>] the list of numeric codes
+      # @param index [Integer] the current index
+      #
+      # @return [Integer] the updated index after consuming needed codes
+      # @rbs (Array[Integer] codes_array, Integer index) -> Integer
+      def apply_single_code(codes_array, index) # rubocop:disable Metrics/MethodLength
+        code = codes_array[index]
+        return index + 1 if code.nil?
+
+        case code
+        when 0
+          reset_segment!
+          index + 1
+        when 30..37, 40..47
+          apply_basic_color(code)
+          index + 1
+        when 38, 48
+          parse_extended_color(codes_array, index)
+        else
+          apply_style_code(code)
+          index + 1
+        end
+      end
+
+      # Applies a single style code (e.g. 1=bold, 2=dim, 4=underline, etc.) if it matches
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @param code [Integer] the numeric code to check
+      #
+      # @return [void]
+      # @rbs (Integer code) -> void
+      def apply_style_code(code)
+        # If it matches the existing style pattern, add it to @current_segment[:styles]
+        # Typically: 1..9, or 21..29, etc. (Your STYLE_CODE_PATTERN is /(?:[1-9]|2[1-9])/)
+        return unless code.to_s.match?(STYLE_CODE_PATTERN)
+
+        @current_segment[:styles] << code.to_s
+      end
+
+      # Creates and returns a fresh, blank segment
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @return [Hash{Symbol => Object}] a new, empty segment
+      # @rbs () -> Hash[Symbol, untyped]
+      def blank_segment
+        { text: +'', foreground: nil, background: nil, styles: [] }
+      end
+
+      # Scans the string for ANSI sequences or individual characters
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @return [void]
+      # @rbs () -> void
+      def consume_tokens
+        handle_ansi_sequence || handle_character until @scanner.eos?
+      end
+
+      # Finalizes the current segment if any text is present, then resets it
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @return [void]
+      # @rbs () -> void
+      def finalize_segment_if_text!
+        return if @current_segment[:text].empty?
+
+        seg_len = @current_segment[:text].length
+        segment = @current_segment.merge(
+          encoded_start: @encoded_pos - seg_len,
+          encoded_end: @encoded_pos,
+          stripped_start: @stripped_pos - seg_len,
+          stripped_end: @stripped_pos
+        )
+
+        @segments << segment
+        reset_segment!
+      end
+
+      # Attempts to capture an ANSI sequence from the scanner If found, finalizes
+      # the current text segment and applies the sequence
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @return [Boolean] `true` if a sequence was found, `false` if otherwise
+      # @rbs () -> bool
+      def handle_ansi_sequence
+        sequence = @scanner.scan(SEQUENCE_PATTERN)
+        return false unless sequence
+
+        finalize_segment_if_text!
+        apply_ansi_sequence(sequence)
+        @encoded_pos += sequence.length
+        true
+      end
+
+      # Reads a single character from the scanner and appends it to the current segment
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @return [void]
+      # @rbs () -> void
+      def handle_character
+        char = @scanner.getch
+        @current_segment[:text] << char
+        @encoded_pos  += 1
+        @stripped_pos += 1
+      end
+
+      # Parse extended color codes from the array, e.g. 38;5;160 (256-color) or 38;2;R;G;B (24-bit),
+      # and apply them to foreground or background
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @param codes_array [Array<Integer>] the array of codes
+      # @param index [Integer] the current position (where we saw 38 or 48)
+      #
+      # @return [Integer] the updated position in the codes array
+      # @rbs (Array[Integer] codes_array, Integer index) -> Integer
+      def parse_extended_color(codes_array, index)
+        mode_code = codes_array[index + 1]
+
+        return index + 1 unless mode_code
+
+        case mode_code
+        when 5
+          apply_256_color(codes_array, index)
+        when 2
+          apply_24bit_color(codes_array, index)
+        else
+          index + 1
+        end
+      end
+
+      # Resets the current segment to a fresh, blank state
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @return [void]
+      # @rbs () -> void
+      def reset_segment!
+        @current_segment[:text] = +''
+        @current_segment[:foreground] = nil
+        @current_segment[:background] = nil
+        @current_segment[:styles] = []
+      end
+    end
+  end
+end

--- a/lib/sai/ansi/sequenced_string.rb
+++ b/lib/sai/ansi/sequenced_string.rb
@@ -1,0 +1,475 @@
+# frozen_string_literal: true
+
+require 'forwardable'
+require 'sai/ansi'
+require 'sai/ansi/sequence_processor'
+
+module Sai
+  module ANSI
+    # A representation of a ANSI encoded string and its individual {SequencedString::Segment segments}
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api public
+    class SequencedString
+      # @rbs skip
+      extend Forwardable
+      include Enumerable #[Segment]
+
+      # @!method each
+      #   Iterate over each segment
+      #
+      #   @author {https://aaronmallen.me Aaron Allen}
+      #   @since unreleased
+      #
+      #   @api public
+      #   @return [Enumerator] the Enumerator
+      #
+      # @!method map
+      #   Map over segments
+      #
+      #   @author {https://aaronmallen.me Aaron Allen}
+      #   @since unreleased
+      #
+      #   @api public
+      #   @return [Array] the segments to map over
+      #
+      # @!method size
+      #   Number of segments
+      #
+      #   @author {https://aaronmallen.me Aaron Allen}
+      #   @since unreleased
+      #
+      #   @api public
+      #
+      #   @return [Integer] the number of segments
+      def_delegators :@segments, :each, :empty?, :map, :size # steep:ignore NoMethod
+
+      # @rbs!
+      #   def each: () { (Segment) -> void } -> SequencedString
+      #   def empty?: () -> bool
+      #   def map: () { (Segment) -> untyped } -> Array[untyped]
+      #   def size: () -> Integer
+
+      # Initialize a new instance of SequencedString
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @param string [String] the sequenced string to Segment
+      #
+      # @return [SequencedString] the new instance of SequencedString
+      # @rbs (String string) -> void
+      def initialize(string)
+        @segments = ANSI::SequenceProcessor.process(string).map do |segment_options|
+          Segment.new(**segment_options) # steep:ignore InsufficientKeywordArguments
+        end
+      end
+
+      # Fetch a segment by index
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api public
+      #
+      # @example
+      #   string = SequencedString.new("\e[31mred\e[0m")
+      #   string[0] #=> #<SequencedString::Segment:0x00007f9b3b8b3e10>
+      #
+      # @param index [Integer] the index of the segment to fetch
+      #
+      # @return [Segment, nil] the segment at the index
+      # @rbs (Integer index) -> Segment?
+      def [](index)
+        @segments[index]
+      end
+
+      # Compare the SequencedString to another object
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api public
+      #
+      # @example
+      #   string = "\e[31mred\e[0m"
+      #   SequencedString.new(string) == string #=> true
+      #
+      # @param other [Object] the object to compare to
+      #
+      # @return [Boolean] `true` if the SequencedString is equal to the other object, `false` otherwise
+      # @rbs (untyped other) -> bool
+      def ==(other)
+        (other.is_a?(self.class) && to_s == other.to_s) ||
+          (other.is_a?(String) && to_s == self.class.new(other).to_s)
+      end
+
+      # Combine a sequenced string with another object
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api public
+      #
+      # @example
+      #   sequenced_string = SequencedString.new("\e[31mred\e[0m")
+      #   sequenced_string + " is a color" #=> "\e[31mred\e[0m is a color"
+      #
+      # @param other [Object] the object to combine with
+      #
+      # @return [SequencedString] the combined string
+      # @rbs (untyped other) -> SequencedString
+      def +(other)
+        string = to_s + other.to_s
+        self.class.new(string)
+      end
+
+      # Return just the raw text content with **no ANSI sequences**
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api public
+      #
+      # @example
+      #   string = SequencedString.new("Normal \e[31mred\e[0m")
+      #   string.stripped #=> "Normal red"
+      #
+      # @return [String] the concatenation of all segment text without color or style
+      def stripped
+        map(&:text).join
+      end
+
+      # Return the fully reconstructed string with **all ANSI sequences** (foreground, background, style)
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api public
+      #
+      # @example
+      #   string = SequencedString.new("\e[31mred\e[0m")
+      #   string.to_s #=> "\e[31mred\e[0m"
+      #
+      # @return [String]
+      def to_s
+        build_string
+      end
+      alias to_str to_s
+
+      # Return a string with everything except **background** color sequences removed
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api public
+      #
+      # @example Remove all background colors
+      #   string = SequencedString.new("\e[41mBack\e[0m \e[1mBold\e[0m")
+      #   string.without_background #=> "\e[1mBold\e[0m"
+      #
+      # @return [SequencedString] new instance with background colors removed
+      # @rbs () -> SequencedString
+      def without_background
+        self.class.new(build_string(skip_background: true))
+      end
+
+      # Return a string containing *style* sequences but **no foreground or background colors**
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api public
+      #
+      # @example Remove all colors
+      #   string = SequencedString.new("\e[31mred\e[0m \e[1mbold\e[0m")
+      #   string.without_color #=> "\e[1mbold\e[0m"
+      #
+      # @return [SequencedString] new instance with all colors removed
+      # @rbs () -> SequencedString
+      def without_color
+        self.class.new(build_string(skip_background: true, skip_foreground: true))
+      end
+
+      # Return a string with everything except **foreground** color sequences removed
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api public
+      #
+      # @example Remove all foreground colors
+      #   string = SequencedString.new("\e[41mBack\e[0m \e[1mBold\e[0m")
+      #   string.without_foreground #=> "\e[41mBack\e[0m \e[1mBold\e[0m"
+      #
+      # @return [SequencedString] new instance with foreground colors removed
+      # @rbs () -> SequencedString
+      def without_foreground
+        self.class.new(build_string(skip_foreground: true))
+      end
+
+      # Return a string with specified styles removed
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api public
+      #
+      # @example Remove all styles
+      #   string = SequencedString.new("\e[31mred\e[0m \e[1mbold\e[0m")
+      #   string.without_style #=> "\e[31mred\e[0m"
+      #
+      # @example Remove specific style
+      #   string = SequencedString.new("\e[1;4mBold and Underlined\e[0m")
+      #   string.without_style(:bold) #=> "\e[4mUnderlined\e[0m"
+      #
+      # @param styles [Array<Symbol>] specific styles to remove (default: all)
+      #
+      # @return [SequencedString] new instance with specified styles removed
+      def without_style(*styles)
+        skipped_styles = styles.empty? ? ANSI::STYLES.keys : styles.map(&:to_sym)
+        self.class.new(build_string(skip_styles: skipped_styles))
+      end
+
+      private
+
+      # Build the color sequences for a segment
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @param segment [Segment] the segment to build color sequences for
+      # @param skip_background [Boolean] whether to skip background colors
+      # @param skip_foreground [Boolean] whether to skip foreground colors
+      #
+      # @return [Array<String>] the color sequences
+      # @rbs (Segment segment, ?skip_background: bool, ?skip_foreground: bool) -> Array[String]
+      def build_color_sequences(segment, skip_background: false, skip_foreground: false)
+        [
+          (skip_foreground ? nil : segment.foreground),
+          (skip_background ? nil : segment.background)
+        ].compact
+      end
+
+      # Build a string with specified parts skipped
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @param skip_background [Boolean] whether to skip background colors
+      # @param skip_foreground [Boolean] whether to skip foreground colors
+      # @param skip_styles [Array<Symbol>] styles to skip
+      #
+      # @return [String] the built string
+      # @rbs (?skip_background: bool, ?skip_foreground: bool, ?skip_styles: Array[Symbol]) -> String
+      def build_string(skip_background: false, skip_foreground: false, skip_styles: [])
+        map do |segment|
+          color_sequences = build_color_sequences(segment, skip_background:, skip_foreground:)
+          style_sequences = build_style_sequences(segment, skip_styles: skip_styles)
+          sequences = color_sequences + style_sequences
+
+          out = sequences.empty? ? +'' : "\e[#{sequences.compact.join(';')}m"
+          out << segment.text
+          out << ANSI::RESET unless sequences.empty?
+          out
+        end.join
+      end
+
+      # Build the style sequences for a segment
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @param segment [Segment] the segment to build style sequences for
+      # @param skip_styles [Array<Symbol>] styles to skip
+      #
+      # @return [Array<String>] the style sequences
+      # @rbs (Segment segment, ?skip_styles: Array[Symbol]) -> Array[String]
+      def build_style_sequences(segment, skip_styles: [])
+        return [] if skip_styles.include?(:all)
+
+        segment.styles.filter_map do |style_code|
+          style_name = ANSI::STYLES.key(style_code.to_i)
+          style_code unless skip_styles.include?(style_name)
+        end
+      end
+
+      # A segment of an ANSI encoded string
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api public
+      class Segment
+        # The background color sequences for the Segment
+        #
+        # @author {https://aaronmallen.me Aaron Allen}
+        # @since unreleased
+        #
+        # @api public
+        #
+        # @return [String, nil] the background color sequences
+        attr_reader :background #: String?
+
+        # The foreground color sequences for the Segment
+        #
+        # @author {https://aaronmallen.me Aaron Allen}
+        # @since unreleased
+        #
+        # @api public
+        #
+        # @return [String, nil] the foreground color sequences
+        attr_reader :foreground #: String?
+
+        # The {Location} of the encoded string within the {SequencedString}
+        #
+        # @author {https://aaronmallen.me Aaron Allen}
+        # @since unreleased
+        #
+        # @api public
+        #
+        # @return [Location] the {Location}
+        attr_reader :encoded_location #: Location
+        alias encoded_loc encoded_location
+
+        # The {Location} of the encoded string without it's encoding within the {SequencedString}
+        #
+        # @author {https://aaronmallen.me Aaron Allen}
+        # @since unreleased
+        #
+        # @api public
+        #
+        # @return [Location] the {Location}
+        attr_reader :stripped_location #: Location
+        alias stripped_loc stripped_location
+
+        # The style sequences (bold, underline, etc...) for the segment
+        #
+        # @author {https://aaronmallen.me Aaron Allen}
+        # @since unreleased
+        #
+        # @api public
+        #
+        # @return [Array<String>] the style sequences
+        attr_reader :styles #: Array[String]
+
+        # The raw text of the Segment without any of its ANSI sequences
+        #
+        # @author {https://aaronmallen.me Aaron Allen}
+        # @since unreleased
+        #
+        # @api public
+        #
+        # @return [String]
+        attr_reader :text #: String
+
+        # Initialize a new instance of Segment
+        #
+        # @author {https://aaronmallen.me Aaron Allen}
+        # @since unreleased
+        #
+        # @api private
+        #
+        # @param options [Hash{Symbol => Object}] the options to initialize the Segment with
+        # @option options background [String, nil] the Segment {#background}
+        # @option options foreground [String, nil] the Segment {#foreground}
+        # @option options encoded_end [Integer] the {Location#end_position end_position} of the Segment
+        #   {#encoded_location}
+        # @option options encoded_start [Integer] the {Location#start_position start_position} of the Segment
+        #   {#encoded_location}
+        # @option options stripped_end [Integer] the {Location#end_position end_position} of the Segment
+        #   {#stripped_location}
+        # @option options stripped_start [Integer] the {Location#start_position start_position} of the Segment
+        #   {#stripped_location}
+        # @option options styles [Array<String>] the Segment {#styles}
+        # @option options text [String] the Segment {#text}
+        #
+        # @return [Segment] the new instance of Segment
+        # @rbs (
+        #   ?background: String?,
+        #   ?foreground: String?,
+        #   encoded_end: Integer,
+        #   encoded_start: Integer,
+        #   stripped_end: Integer,
+        #   stripped_start: Integer,
+        #   ?styles: Array[String],
+        #   text: String
+        #   ) -> void
+        def initialize(**options)
+          @background = options.fetch(:background, nil)
+          @foreground = options.fetch(:foreground, nil)
+          @encoded_location = Location.new(
+            end_position: options.fetch(:encoded_end), #: Integer
+            start_position: options.fetch(:encoded_start) #: Integer
+          )
+          @stripped_location = Location.new(
+            end_position: options.fetch(:stripped_end), #: Integer
+            start_position: options.fetch(:stripped_start) #: Integer
+          )
+          @styles = options.fetch(:styles, [])
+          @text = options.fetch(:text)
+
+          freeze
+        end
+
+        # The location of the {Segment} within a {SequencedString}
+        #
+        # @author {https://aaronmallen.me Aaron Allen}
+        # @since unreleased
+        #
+        # @api public
+        class Location
+          # The ending position of the Location
+          #
+          # @author {https://aaronmallen.me Aaron Allen}
+          # @since unreleased
+          #
+          # @api public
+          #
+          # @return [Integer] the end position
+          attr_reader :end_position #: Integer
+          alias end_pos end_position
+
+          # The starting position of the Location
+          #
+          # @author {https://aaronmallen.me Aaron Allen}
+          # @since unreleased
+          #
+          # @api public
+          #
+          # @return [Integer] the start position
+          attr_reader :start_position #: Integer
+          alias start_pos start_position
+
+          # Initialize a new instance of Location
+          #
+          # @author {https://aaronmallen.me Aaron Allen}
+          # @since unreleased
+          #
+          # @api private
+          #
+          # @param end_position [Integer] the {#end_position} of the location
+          # @param start_position [Integer] the {#start_position} of the location
+          #
+          # @return [Location] the new instance of Location
+          # @rbs (end_position: Integer, start_position: Integer) -> void
+          def initialize(end_position:, start_position:)
+            @end_position = end_position
+            @start_position = start_position
+            freeze
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/sai/decorator.rb
+++ b/lib/sai/decorator.rb
@@ -2,6 +2,7 @@
 
 require 'sai'
 require 'sai/ansi'
+require 'sai/ansi/sequenced_string'
 require 'sai/conversion/color_sequence'
 
 module Sai
@@ -39,7 +40,7 @@ module Sai
     #   @api public
     #
     #   @example
-    #     decorator.black.decorate('Hello, world!') #=> "\e[30mHello, world!\e[0m"
+    #     decorator.black.decorate('Hello, world!').to_s #=> "\e[30mHello, world!\e[0m"
     #
     #   @return [Decorator] a new instance of Decorator with the color applied
     #
@@ -52,7 +53,7 @@ module Sai
     #   @api public
     #
     #   @example
-    #     decorator.blue.decorate('Hello, world!') #=> "\e[34mHello, world!\e[0m"
+    #     decorator.blue.decorate('Hello, world!').to_s #=> "\e[34mHello, world!\e[0m"
     #
     #   @return [Decorator] a new instance of Decorator with the color applied
     #
@@ -65,7 +66,7 @@ module Sai
     #   @api public
     #
     #   @example
-    #     decorator.bright_black.decorate('Hello, world!') #=> "\e[90mHello, world!\e[0m"
+    #     decorator.bright_black.decorate('Hello, world!').to_s #=> "\e[90mHello, world!\e[0m"
     #
     #   @return [Decorator] a new instance of Decorator with the color applied
     #
@@ -75,7 +76,7 @@ module Sai
     #   @api public
     #
     #   @example
-    #     decorator.bright_blue.decorate('Hello, world!') #=> "\e[94mHello, world!\e[0m"
+    #     decorator.bright_blue.decorate('Hello, world!').to_s #=> "\e[94mHello, world!\e[0m"
     #
     #   @return [Decorator] a new instance of Decorator with the color applied
     #
@@ -85,7 +86,7 @@ module Sai
     #   @api public
     #
     #   @example
-    #     decorator.bright_cyan.decorate('Hello, world!') #=> "\e[96mHello, world!\e[0m"
+    #     decorator.bright_cyan.decorate('Hello, world!').to_s #=> "\e[96mHello, world!\e[0m"
     #
     #   @return [Decorator] a new instance of Decorator with the color applied
     #
@@ -95,7 +96,7 @@ module Sai
     #   @api public
     #
     #   @example
-    #     decorator.bright_green.decorate('Hello, world!') #=> "\e[92mHello, world!\e[0m"
+    #     decorator.bright_green.decorate('Hello, world!').to_s #=> "\e[92mHello, world!\e[0m"
     #
     #   @return [Decorator] a new instance of Decorator with the color applied
     #
@@ -105,7 +106,7 @@ module Sai
     #   @api public
     #
     #   @example
-    #     decorator.bright_magenta.decorate('Hello, world!') #=> "\e[95mHello, world!\e[0m"
+    #     decorator.bright_magenta.decorate('Hello, world!').to_s #=> "\e[95mHello, world!\e[0m"
     #
     #   @return [Decorator] a new instance of Decorator with the color applied
     #
@@ -115,7 +116,7 @@ module Sai
     #   @api public
     #
     #   @example
-    #     decorator.bright_red.decorate('Hello, world!') #=> "\e[91mHello, world!\e[0m"
+    #     decorator.bright_red.decorate('Hello, world!').to_s #=> "\e[91mHello, world!\e[0m"
     #
     #   @return [Decorator] a new instance of Decorator with the color applied
     #
@@ -125,7 +126,7 @@ module Sai
     #   @api public
     #
     #   @example
-    #     decorator.bright_white.decorate('Hello, world!') #=> "\e[97mHello, world!\e[0m"
+    #     decorator.bright_white.decorate('Hello, world!').to_s #=> "\e[97mHello, world!\e[0m"
     #
     #   @return [Decorator] a new instance of Decorator with the color applied
     #
@@ -135,7 +136,7 @@ module Sai
     #   @api public
     #
     #   @example
-    #     decorator.bright_yellow.decorate('Hello, world!') #=> "\e[93mHello, world!\e[0m"
+    #     decorator.bright_yellow.decorate('Hello, world!').to_s #=> "\e[93mHello, world!\e[0m"
     #
     #   @return [Decorator] a new instance of Decorator with the color applied
     #
@@ -145,7 +146,7 @@ module Sai
     #   @api public
     #
     #   @example
-    #     decorator.cyan.decorate('Hello, world!') #=> "\e[36mHello, world!\e[0m"
+    #     decorator.cyan.decorate('Hello, world!').to_s #=> "\e[36mHello, world!\e[0m"
     #
     #   @return [Decorator] a new instance of Decorator with the color applied
     #
@@ -155,7 +156,7 @@ module Sai
     #   @api public
     #
     #   @example
-    #     decorator.green.decorate('Hello, world!') #=> "\e[32mHello, world!\e[0m"
+    #     decorator.green.decorate('Hello, world!').to_s #=> "\e[32mHello, world!\e[0m"
     #
     #   @return [Decorator] a new instance of Decorator with the color applied
     #
@@ -165,7 +166,7 @@ module Sai
     #   @api public
     #
     #   @example
-    #     decorator.magenta.decorate('Hello, world!') #=> "\e[35mHello, world!\e[0m"
+    #     decorator.magenta.decorate('Hello, world!').to_s #=> "\e[35mHello, world!\e[0m"
     #
     #   @return [Decorator] a new instance of Decorator with the color applied
     #
@@ -178,7 +179,7 @@ module Sai
     #   @api public
     #
     #   @example
-    #     decorator.on_black.decorate('Hello, world!') #=> "\e[40mHello, world!\e[0m"
+    #     decorator.on_black.decorate('Hello, world!').to_s #=> "\e[40mHello, world!\e[0m"
     #
     #   @return [Decorator] a new instance of Decorator with the color applied
     #
@@ -191,7 +192,7 @@ module Sai
     #   @api public
     #
     #   @example
-    #     decorator.on_blue.decorate('Hello, world!') #=> "\e[44mHello, world!\e[0m"
+    #     decorator.on_blue.decorate('Hello, world!').to_s #=> "\e[44mHello, world!\e[0m"
     #
     #   @return [Decorator] a new instance of Decorator with the color applied
     #
@@ -204,7 +205,7 @@ module Sai
     #   @api public
     #
     #   @example
-    #     decorator.on_bright_black.decorate('Hello, world!') #=> "\e[100mHello, world!\e[0m"
+    #     decorator.on_bright_black.decorate('Hello, world!').to_s #=> "\e[100mHello, world!\e[0m"
     #
     #   @return [Decorator] a new instance of Decorator with the color applied
     #
@@ -217,7 +218,7 @@ module Sai
     #   @api public
     #
     #   @example
-    #     decorator.on_bright_blue.decorate('Hello, world!') #=> "\e[104mHello, world!\e[0m"
+    #     decorator.on_bright_blue.decorate('Hello, world!').to_s #=> "\e[104mHello, world!\e[0m"
     #
     #   @return [Decorator] a new instance of Decorator with the color applied
     #
@@ -230,7 +231,7 @@ module Sai
     #   @api public
     #
     #   @example
-    #     decorator.on_bright_cyan.decorate('Hello, world!') #=> "\e[106mHello, world!\e[0m"
+    #     decorator.on_bright_cyan.decorate('Hello, world!').to_s #=> "\e[106mHello, world!\e[0m"
     #
     #   @return [Decorator] a new instance of Decorator with the color applied
     #
@@ -243,7 +244,7 @@ module Sai
     #   @api public
     #
     #   @example
-    #     decorator.on_bright_green.decorate('Hello, world!') #=> "\e[102mHello, world!\e[0m"
+    #     decorator.on_bright_green.decorate('Hello, world!').to_s #=> "\e[102mHello, world!\e[0m"
     #
     #   @return [Decorator] a new instance of Decorator with the color applied
     #
@@ -256,7 +257,7 @@ module Sai
     #   @api public
     #
     #   @example
-    #     decorator.on_bright_magenta.decorate('Hello, world!') #=> "\e[105mHello, world!\e[0m"
+    #     decorator.on_bright_magenta.decorate('Hello, world!').to_s #=> "\e[105mHello, world!\e[0m"
     #
     #   @return [Decorator] a new instance of Decorator with the color applied
     #
@@ -269,7 +270,7 @@ module Sai
     #   @api public
     #
     #   @example
-    #     decorator.on_bright_red.decorate('Hello, world!') #=> "\e[101mHello, world!\e[0m"
+    #     decorator.on_bright_red.decorate('Hello, world!').to_s #=> "\e[101mHello, world!\e[0m"
     #
     #   @return [Decorator] a new instance of Decorator with the color applied
     #
@@ -282,7 +283,7 @@ module Sai
     #   @api public
     #
     #   @example
-    #     decorator.on_bright_white.decorate('Hello, world!') #=> "\e[107mHello, world!\e[0m"
+    #     decorator.on_bright_white.decorate('Hello, world!').to_s #=> "\e[107mHello, world!\e[0m"
     #
     #   @return [Decorator] a new instance of Decorator with the color applied
     #
@@ -295,7 +296,7 @@ module Sai
     #   @api public
     #
     #   @example
-    #     decorator.on_bright_yellow.decorate('Hello, world!') #=> "\e[103mHello, world!\e[0m"
+    #     decorator.on_bright_yellow.decorate('Hello, world!').to_s #=> "\e[103mHello, world!\e[0m"
     #
     #   @return [Decorator] a new instance of Decorator with the color applied
     #
@@ -308,7 +309,7 @@ module Sai
     #   @api public
     #
     #   @example
-    #     decorator.on_cyan.decorate('Hello, world!') #=> "\e[46mHello, world!\e[0m"
+    #     decorator.on_cyan.decorate('Hello, world!').to_s #=> "\e[46mHello, world!\e[0m"
     #
     #   @return [Decorator] a new instance of Decorator with the color applied
     #
@@ -321,7 +322,7 @@ module Sai
     #   @api public
     #
     #   @example
-    #     decorator.on_green.decorate('Hello, world!') #=> "\e[42mHello, world!\e[0m"
+    #     decorator.on_green.decorate('Hello, world!').to_s #=> "\e[42mHello, world!\e[0m"
     #
     #   @return [Decorator] a new instance of Decorator with the color applied
     #
@@ -334,7 +335,7 @@ module Sai
     #   @api public
     #
     #   @example
-    #     decorator.on_magenta.decorate('Hello, world!') #=> "\e[45mHello, world!\e[0m"
+    #     decorator.on_magenta.decorate('Hello, world!').to_s #=> "\e[45mHello, world!\e[0m"
     #
     #   @return [Decorator] a new instance of Decorator with the color applied
     #
@@ -347,7 +348,7 @@ module Sai
     #   @api public
     #
     #   @example
-    #     decorator.on_red.decorate('Hello, world!') #=> "\e[41mHello, world!\e[0m"
+    #     decorator.on_red.decorate('Hello, world!').to_s #=> "\e[41mHello, world!\e[0m"
     #
     #   @return [Decorator] a new instance of Decorator with the color applied
     #
@@ -360,7 +361,7 @@ module Sai
     #   @api public
     #
     #   @example
-    #     decorator.on_white.decorate('Hello, world!') #=> "\e[47mHello, world!\e[0m"
+    #     decorator.on_white.decorate('Hello, world!').to_s #=> "\e[47mHello, world!\e[0m"
     #
     #   @return [Decorator] a new instance of Decorator with the color applied
     #
@@ -373,7 +374,7 @@ module Sai
     #   @api public
     #
     #   @example
-    #     decorator.on_yellow.decorate('Hello, world!') #=> "\e[43mHello, world!\e[0m"
+    #     decorator.on_yellow.decorate('Hello, world!').to_s #=> "\e[43mHello, world!\e[0m"
     #
     #   @return [Decorator] a new instance of Decorator with the color applied
     #
@@ -383,7 +384,7 @@ module Sai
     #   @api public
     #
     #   @example
-    #     decorator.red.decorate('Hello, world!') #=> "\e[31mHello, world!\e[0m"
+    #     decorator.red.decorate('Hello, world!').to_s #=> "\e[31mHello, world!\e[0m"
     #
     #   @return [Decorator] a new instance of Decorator with the color applied
     #
@@ -393,7 +394,7 @@ module Sai
     #   @api public
     #
     #   @example
-    #     decorator.white.decorate('Hello, world!') #=> "\e[37mHello, world!\e[0m"
+    #     decorator.white.decorate('Hello, world!').to_s #=> "\e[37mHello, world!\e[0m"
     #
     #   @return [Decorator] a new instance of Decorator with the color applied
     #
@@ -403,7 +404,7 @@ module Sai
     #   @api public
     #
     #   @example
-    #     decorator.yellow.decorate('Hello, world!') #=> "\e[33mHello, world!\e[0m"
+    #     decorator.yellow.decorate('Hello, world!').to_s #=> "\e[33mHello, world!\e[0m"
     #
     #   @return [Decorator] a new instance of Decorator with the color applied
     ANSI::COLOR_NAMES.each_key do |color|
@@ -457,7 +458,7 @@ module Sai
     #   @api public
     #
     #   @example
-    #     decorator.blink.decorate('Hello, world!') #=> "\e[5mHello, world!\e[0m"
+    #     decorator.blink.decorate('Hello, world!').to_s #=> "\e[5mHello, world!\e[0m"
     #
     #   @return [Decorator] a new instance of Decorator with the style applied
     #
@@ -470,7 +471,7 @@ module Sai
     #   @api public
     #
     #   @example
-    #     decorator.bold.decorate('Hello, world!') #=> "\e[1mHello, world!\e[0m"
+    #     decorator.bold.decorate('Hello, world!').to_s #=> "\e[1mHello, world!\e[0m"
     #
     #   @return [Decorator] a new instance of Decorator with the style applied
     #
@@ -483,7 +484,7 @@ module Sai
     #   @api public
     #
     #   @example
-    #     decorator.conceal.decorate('Hello, world!') #=> "\e[8mHello, world!\e[0m"
+    #     decorator.conceal.decorate('Hello, world!').to_s #=> "\e[8mHello, world!\e[0m"
     #
     #   @return [Decorator] a new instance of Decorator with the style applied
     #
@@ -496,7 +497,7 @@ module Sai
     #   @api public
     #
     #   @example
-    #     decorator.dim.decorate('Hello, world!') #=> "\e[2mHello, world!\e[0m"
+    #     decorator.dim.decorate('Hello, world!').to_s #=> "\e[2mHello, world!\e[0m"
     #
     #   @return [Decorator] a new instance of Decorator with the style applied
     #
@@ -509,7 +510,7 @@ module Sai
     #   @api public
     #
     #   @example
-    #     decorator.italic.decorate('Hello, world!') #=> "\e[3mHello, world!\e[0m"
+    #     decorator.italic.decorate('Hello, world!').to_s #=> "\e[3mHello, world!\e[0m"
     #
     #   @return [Decorator] a new instance of Decorator with the style applied
     #
@@ -522,7 +523,7 @@ module Sai
     #   @api public
     #
     #   @example
-    #     decorator.no_blink.decorate('Hello, world!') #=> "\e[25mHello, world!\e[0m"
+    #     decorator.no_blink.decorate('Hello, world!').to_s #=> "\e[25mHello, world!\e[0m"
     #
     #   @return [Decorator] a new instance of Decorator with the style applied
     #
@@ -535,7 +536,7 @@ module Sai
     #   @api public
     #
     #   @example
-    #     decorator.no_conceal.decorate('Hello, world!') #=> "\e[28mHello, world!\e[0m"
+    #     decorator.no_conceal.decorate('Hello, world!').to_s #=> "\e[28mHello, world!\e[0m"
     #
     #   @return [Decorator] a new instance of Decorator with the style applied
     #
@@ -548,7 +549,7 @@ module Sai
     #   @api public
     #
     #   @example
-    #     decorator.no_italic.decorate('Hello, world!') #=> "\e[23mHello, world!\e[0m"
+    #     decorator.no_italic.decorate('Hello, world!').to_s #=> "\e[23mHello, world!\e[0m"
     #
     #   @return [Decorator] a new instance of Decorator with the style applied
     #
@@ -561,7 +562,7 @@ module Sai
     #   @api public
     #
     #   @example
-    #     decorator.no_reverse.decorate('Hello, world!') #=> "\e[27mHello, world!\e[0m"
+    #     decorator.no_reverse.decorate('Hello, world!').to_s #=> "\e[27mHello, world!\e[0m"
     #
     #   @return [Decorator] a new instance of Decorator with the style applied
     #
@@ -574,7 +575,7 @@ module Sai
     #   @api public
     #
     #   @example
-    #     decorator.no_strike.decorate('Hello, world!') #=> "\e[29mHello, world!\e[0m"
+    #     decorator.no_strike.decorate('Hello, world!').to_s #=> "\e[29mHello, world!\e[0m"
     #
     #   @return [Decorator] a new instance of Decorator with the style applied
     #
@@ -587,7 +588,7 @@ module Sai
     #   @api public
     #
     #   @example
-    #     decorator.no_underline.decorate('Hello, world!') #=> "\e[24mHello, world!\e[0m"
+    #     decorator.no_underline.decorate('Hello, world!').to_s #=> "\e[24mHello, world!\e[0m"
     #
     #   @return [Decorator] a new instance of Decorator with the style applied
     #
@@ -600,7 +601,7 @@ module Sai
     #   @api public
     #
     #   @example
-    #     decorator.normal_intensity.decorate('Hello, world!') #=> "\e[22mHello, world!\e[0m"
+    #     decorator.normal_intensity.decorate('Hello, world!').to_s #=> "\e[22mHello, world!\e[0m"
     #
     #   @return [Decorator] a new instance of Decorator with the style applied
     #
@@ -613,7 +614,7 @@ module Sai
     #   @api public
     #
     #   @example
-    #     decorator.rapid_blink.decorate('Hello, world!') #=> "\e[6mHello, world!\e[0m"
+    #     decorator.rapid_blink.decorate('Hello, world!').to_s #=> "\e[6mHello, world!\e[0m"
     #
     #   @return [Decorator] a new instance of Decorator with the style applied
     #
@@ -626,7 +627,7 @@ module Sai
     #   @api public
     #
     #   @example
-    #     decorator.reverse.decorate('Hello, world!') #=> "\e[7mHello, world!\e[0m"
+    #     decorator.reverse.decorate('Hello, world!').to_s #=> "\e[7mHello, world!\e[0m"
     #
     #   @return [Decorator] a new instance of Decorator with the style applied
     #
@@ -639,7 +640,7 @@ module Sai
     #   @api public
     #
     #   @example
-    #     decorator.strike.decorate('Hello, world!') #=> "\e[9mHello, world!\e[0m"
+    #     decorator.strike.decorate('Hello, world!').to_s #=> "\e[9mHello, world!\e[0m"
     #
     #   @return [Decorator] a new instance of Decorator with the style applied
     #
@@ -652,7 +653,7 @@ module Sai
     #   @api public
     #
     #   @example
-    #     decorator.underline.decorate('Hello, world!') #=> "\e[4mHello, world!\e[0m"
+    #     decorator.underline.decorate('Hello, world!').to_s #=> "\e[4mHello, world!\e[0m"
     #
     #   @return [Decorator] a new instance of Decorator with the style applied
     ANSI::STYLES.each_key do |style|
@@ -687,15 +688,14 @@ module Sai
     # @api public
     #
     # @example
-    #   decorator.red.on_blue.bold.decorate('Hello, world!')
-    #   #=> "\e[38;2;205;0;0m\e[48;2;0;0;238m\e[1mHello, world!\e[0m"
+    #   decorator.red.on_blue.bold.decorate('Hello, world!').to_s #=> "\e[38;5;160;48;5;21;1mHello, world!\e[0m"
     #
     # @param text [String] the text to decorate
     #
-    # @return [String] the decorated text
-    # @rbs (String text) -> String
+    # @return [ANSI::SequencedString] the decorated text
+    # @rbs (String text) -> ANSI::SequencedString
     def decorate(text)
-      return text unless should_decorate?
+      return ANSI::SequencedString.new(text) unless should_decorate?
 
       sequences = [
         @foreground && Conversion::ColorSequence.resolve(@foreground, @mode),
@@ -703,7 +703,7 @@ module Sai
         @styles.map { |style| "\e[#{ANSI::STYLES[style]}m" }.join
       ].compact.join
 
-      "#{sequences}#{text}#{ANSI::RESET}"
+      ANSI::SequencedString.new("#{sequences}#{text}#{ANSI::RESET}")
     end
     alias apply decorate
     alias call decorate
@@ -717,7 +717,7 @@ module Sai
     # @api public
     #
     # @example
-    #   decorator.hex("#EB4133").decorate('Hello, world!') #=> "\e[38;2;235;65;51mHello, world!\e[0m"
+    #   decorator.hex("#EB4133").decorate('Hello, world!').to_s #=> "\e[38;2;235;65;51mHello, world!\e[0m"
     #
     # @param code [String] the hex color code
     #
@@ -738,7 +738,7 @@ module Sai
     # @api public
     #
     # @example
-    #   decorator.on_hex("#EB4133").decorate('Hello, world!') #=> "\e[48;2;235;65;51mHello, world!\e[0m"
+    #   decorator.on_hex("#EB4133").decorate('Hello, world!').to_s #=> "\e[48;2;235;65;51mHello, world!\e[0m"
     #
     # @param code [String] the hex color code
     #
@@ -759,7 +759,7 @@ module Sai
     # @api public
     #
     # @example
-    #   decorator.on_rgb(235, 65, 51).decorate('Hello, world!') #=> "\e[48;2;235;65;51mHello, world!\e[0m"
+    #   decorator.on_rgb(235, 65, 51).decorate('Hello, world!').to_s #=> "\e[48;2;235;65;51mHello, world!\e[0m"
     #
     # @param red [Integer] the red component
     # @param green [Integer] the green component
@@ -784,7 +784,7 @@ module Sai
     # @api public
     #
     # @example
-    #   decorator.rgb(235, 65, 51).decorate('Hello, world!') #=> "\e[38;2;235;65;51mHello, world!\e[0m"
+    #   decorator.rgb(235, 65, 51).decorate('Hello, world!').to_s #=> "\e[38;2;235;65;51mHello, world!\e[0m"
     #
     # @param red [Integer] the red component
     # @param green [Integer] the green component

--- a/sai.gemspec
+++ b/sai.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.1'
 
   spec.files = Dir.chdir(__dir__) do
-    Dir['{lib,sig}/**/*', '.yardopts', 'CHANGELOG.md', 'LICENSE', 'README.md']
+    Dir['{lib,sig}/**/*', 'docs/USAGE.md', '.yardopts', 'CHANGELOG.md', 'LICENSE', 'README.md']
       .reject { |f| File.directory?(f) }
   end
 

--- a/sig/manifest.yaml
+++ b/sig/manifest.yaml
@@ -1,0 +1,2 @@
+dependencies:
+  - name: strscan

--- a/sig/manifest.yaml
+++ b/sig/manifest.yaml
@@ -1,2 +1,3 @@
 dependencies:
+  - name: forwardable
   - name: strscan

--- a/sig/sai.rbs
+++ b/sig/sai.rbs
@@ -150,6 +150,22 @@ module Sai
 
   def yellow: () -> Decorator
 
+  # Sequence a string with ANSI escape codes
+  #
+  # @author {https://aaronmallen.me Aaron Allen}
+  # @since unreleased
+  #
+  # @api public
+  #
+  # @example Sequence a string with ANSI escape codes
+  #   Sai.sequence("\e[38;2;205;0;0mHello, World!\e[0m") #=> #<Sai::ANSI::SequencedString:0x123>
+  #
+  # @param text [String] the text to sequence
+  #
+  # @return [ANSI::SequencedString] the sequenced string
+  # @rbs (String text) -> ANSI::SequencedString
+  def self.sequence: (String text) -> ANSI::SequencedString
+
   # The supported color modes for the terminal
   #
   # @author {https://aaronmallen.me Aaron Allen}

--- a/sig/sai/ansi/sequence_processor.rbs
+++ b/sig/sai/ansi/sequence_processor.rbs
@@ -1,0 +1,253 @@
+# Generated from lib/sai/ansi/sequence_processor.rb with RBS::Inline
+
+module Sai
+  module ANSI
+    # Extract ANSI sequence information from a string
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api private
+    class SequenceProcessor
+      # The pattern to extract ANSI sequences from a string
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @return [Regexp] the pattern
+      SEQUENCE_PATTERN: Regexp
+
+      # Matches the code portion of style sequences
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @return [Regexp] the pattern
+      STYLE_CODE_PATTERN: Regexp
+
+      # Initialize a new instance of SequenceProcessor and parse the provided string
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @param string [String] the string to parse
+      #
+      # @return [Array<Hash{Symbol => Object}>] the segments
+      # @rbs (String string) -> Array[Hash[Symbol, untyped]]
+      def self.process: (String string) -> Array[Hash[Symbol, untyped]]
+
+      # Initialize a new instance of SequenceProcessor
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @param string [String] the string to parse
+      #
+      # @return [SequenceProcessor] the new instance of SequenceProcessor
+      # @rbs (String string) -> void
+      def initialize: (String string) -> void
+
+      # Parse a string and return a hash of segments
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @return [Array<Hash{Symbol => Object}>] the segments
+      # @rbs () -> Array[Hash[Symbol, untyped]]
+      def process: () -> Array[Hash[Symbol, untyped]]
+
+      private
+
+      # Applies 24-bit truecolor (e.g., 38;2;R;G;B or 48;2;R;G;B)
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @param codes_array [Array<Integer>]
+      # @param index [Integer]
+      #
+      # @return [Integer] the updated index (consumed 5 codes)
+      # @rbs (Array[Integer] codes_array, Integer index) -> Integer
+      def apply_24bit_color: (Array[Integer] codes_array, Integer index) -> Integer
+
+      # Applies 256-color mode (e.g., 38;5;160 or 48;5;21)
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @param codes_array [Array<Integer>]
+      # @param index [Integer]
+      #
+      # @return [Integer] the updated index (consumed 3 codes)
+      # @rbs (Array[Integer] codes_array, Integer index) -> Integer
+      def apply_256_color: (Array[Integer] codes_array, Integer index) -> Integer
+
+      # Applies the appropriate action for the provided ANSI sequence
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @param sequence [String] an ANSI sequence (e.g. "\e[31m", "\e[0m")
+      #
+      # @return [void]
+      # @rbs (String sequence) -> void
+      def apply_ansi_sequence: (String sequence) -> void
+
+      # Applies a basic color (FG or BG) in the range 30..37 (FG) or 40..47 (BG)
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @param code [Integer] the numeric color code
+      #
+      # @return [void]
+      # @rbs (Integer code) -> void
+      def apply_basic_color: (Integer code) -> void
+
+      # Parse all numeric codes in the provided string, applying them in order (just like a real ANSI terminal)
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @param codes_string [String] e.g. "38;5;160;48;5;21;1"
+      #
+      # @return [void]
+      # @rbs (String codes_string) -> void
+      def apply_codes: (String codes_string) -> void
+
+      # Applies a single code (or group) from the array. This might be:
+      #  - 0 => reset
+      #  - 30..37 => basic FG color
+      #  - 40..47 => basic BG color
+      #  - 38 or 48 => extended color sequence
+      #  - otherwise => style code (bold, underline, etc.)
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @param codes_array [Array<Integer>] the list of numeric codes
+      # @param index [Integer] the current index
+      #
+      # @return [Integer] the updated index after consuming needed codes
+      # @rbs (Array[Integer] codes_array, Integer index) -> Integer
+      def apply_single_code: (Array[Integer] codes_array, Integer index) -> Integer
+
+      # Applies a single style code (e.g. 1=bold, 2=dim, 4=underline, etc.) if it matches
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @param code [Integer] the numeric code to check
+      #
+      # @return [void]
+      # @rbs (Integer code) -> void
+      def apply_style_code: (Integer code) -> void
+
+      # Creates and returns a fresh, blank segment
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @return [Hash{Symbol => Object}] a new, empty segment
+      # @rbs () -> Hash[Symbol, untyped]
+      def blank_segment: () -> Hash[Symbol, untyped]
+
+      # Scans the string for ANSI sequences or individual characters
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @return [void]
+      # @rbs () -> void
+      def consume_tokens: () -> void
+
+      # Finalizes the current segment if any text is present, then resets it
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @return [void]
+      # @rbs () -> void
+      def finalize_segment_if_text!: () -> void
+
+      # Attempts to capture an ANSI sequence from the scanner If found, finalizes
+      # the current text segment and applies the sequence
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @return [Boolean] `true` if a sequence was found, `false` if otherwise
+      # @rbs () -> bool
+      def handle_ansi_sequence: () -> bool
+
+      # Reads a single character from the scanner and appends it to the current segment
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @return [void]
+      # @rbs () -> void
+      def handle_character: () -> void
+
+      # Parse extended color codes from the array, e.g. 38;5;160 (256-color) or 38;2;R;G;B (24-bit),
+      # and apply them to foreground or background
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @param codes_array [Array<Integer>] the array of codes
+      # @param index [Integer] the current position (where we saw 38 or 48)
+      #
+      # @return [Integer] the updated position in the codes array
+      # @rbs (Array[Integer] codes_array, Integer index) -> Integer
+      def parse_extended_color: (Array[Integer] codes_array, Integer index) -> Integer
+
+      # Resets the current segment to a fresh, blank state
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @return [void]
+      # @rbs () -> void
+      def reset_segment!: () -> void
+    end
+  end
+end

--- a/sig/sai/ansi/sequenced_string.rbs
+++ b/sig/sai/ansi/sequenced_string.rbs
@@ -1,0 +1,380 @@
+# Generated from lib/sai/ansi/sequenced_string.rb with RBS::Inline
+
+module Sai
+  module ANSI
+    # A representation of a ANSI encoded string and its individual {SequencedString::Segment segments}
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api public
+    class SequencedString
+      include Enumerable[Segment]
+
+      def each: () { (Segment) -> void } -> SequencedString
+
+      def empty?: () -> bool
+
+      def map: () { (Segment) -> untyped } -> Array[untyped]
+
+      def size: () -> Integer
+
+      # Initialize a new instance of SequencedString
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @param string [String] the sequenced string to Segment
+      #
+      # @return [SequencedString] the new instance of SequencedString
+      # @rbs (String string) -> void
+      def initialize: (String string) -> void
+
+      # Fetch a segment by index
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api public
+      #
+      # @example
+      #   string = SequencedString.new("\e[31mred\e[0m")
+      #   string[0] #=> #<SequencedString::Segment:0x00007f9b3b8b3e10>
+      #
+      # @param index [Integer] the index of the segment to fetch
+      #
+      # @return [Segment, nil] the segment at the index
+      # @rbs (Integer index) -> Segment?
+      def []: (Integer index) -> Segment?
+
+      # Compare the SequencedString to another object
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api public
+      #
+      # @example
+      #   string = "\e[31mred\e[0m"
+      #   SequencedString.new(string) == string #=> true
+      #
+      # @param other [Object] the object to compare to
+      #
+      # @return [Boolean] `true` if the SequencedString is equal to the other object, `false` otherwise
+      # @rbs (untyped other) -> bool
+      def ==: (untyped other) -> bool
+
+      # Combine a sequenced string with another object
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api public
+      #
+      # @example
+      #   sequenced_string = SequencedString.new("\e[31mred\e[0m")
+      #   sequenced_string + " is a color" #=> "\e[31mred\e[0m is a color"
+      #
+      # @param other [Object] the object to combine with
+      #
+      # @return [SequencedString] the combined string
+      # @rbs (untyped other) -> SequencedString
+      def +: (untyped other) -> SequencedString
+
+      # Return just the raw text content with **no ANSI sequences**
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api public
+      #
+      # @example
+      #   string = SequencedString.new("Normal \e[31mred\e[0m")
+      #   string.stripped #=> "Normal red"
+      #
+      # @return [String] the concatenation of all segment text without color or style
+      def stripped: () -> untyped
+
+      # Return the fully reconstructed string with **all ANSI sequences** (foreground, background, style)
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api public
+      #
+      # @example
+      #   string = SequencedString.new("\e[31mred\e[0m")
+      #   string.to_s #=> "\e[31mred\e[0m"
+      #
+      # @return [String]
+      def to_s: () -> untyped
+
+      alias to_str to_s
+
+      # Return a string with everything except **background** color sequences removed
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api public
+      #
+      # @example Remove all background colors
+      #   string = SequencedString.new("\e[41mBack\e[0m \e[1mBold\e[0m")
+      #   string.without_background #=> "\e[1mBold\e[0m"
+      #
+      # @return [SequencedString] new instance with background colors removed
+      # @rbs () -> SequencedString
+      def without_background: () -> SequencedString
+
+      # Return a string containing *style* sequences but **no foreground or background colors**
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api public
+      #
+      # @example Remove all colors
+      #   string = SequencedString.new("\e[31mred\e[0m \e[1mbold\e[0m")
+      #   string.without_color #=> "\e[1mbold\e[0m"
+      #
+      # @return [SequencedString] new instance with all colors removed
+      # @rbs () -> SequencedString
+      def without_color: () -> SequencedString
+
+      # Return a string with everything except **foreground** color sequences removed
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api public
+      #
+      # @example Remove all foreground colors
+      #   string = SequencedString.new("\e[41mBack\e[0m \e[1mBold\e[0m")
+      #   string.without_foreground #=> "\e[41mBack\e[0m \e[1mBold\e[0m"
+      #
+      # @return [SequencedString] new instance with foreground colors removed
+      # @rbs () -> SequencedString
+      def without_foreground: () -> SequencedString
+
+      # Return a string with specified styles removed
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api public
+      #
+      # @example Remove all styles
+      #   string = SequencedString.new("\e[31mred\e[0m \e[1mbold\e[0m")
+      #   string.without_style #=> "\e[31mred\e[0m"
+      #
+      # @example Remove specific style
+      #   string = SequencedString.new("\e[1;4mBold and Underlined\e[0m")
+      #   string.without_style(:bold) #=> "\e[4mUnderlined\e[0m"
+      #
+      # @param styles [Array<Symbol>] specific styles to remove (default: all)
+      #
+      # @return [SequencedString] new instance with specified styles removed
+      def without_style: (*untyped styles) -> untyped
+
+      private
+
+      # Build the color sequences for a segment
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @param segment [Segment] the segment to build color sequences for
+      # @param skip_background [Boolean] whether to skip background colors
+      # @param skip_foreground [Boolean] whether to skip foreground colors
+      #
+      # @return [Array<String>] the color sequences
+      # @rbs (Segment segment, ?skip_background: bool, ?skip_foreground: bool) -> Array[String]
+      def build_color_sequences: (Segment segment, ?skip_background: bool, ?skip_foreground: bool) -> Array[String]
+
+      # Build a string with specified parts skipped
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @param skip_background [Boolean] whether to skip background colors
+      # @param skip_foreground [Boolean] whether to skip foreground colors
+      # @param skip_styles [Array<Symbol>] styles to skip
+      #
+      # @return [String] the built string
+      # @rbs (?skip_background: bool, ?skip_foreground: bool, ?skip_styles: Array[Symbol]) -> String
+      def build_string: (?skip_background: bool, ?skip_foreground: bool, ?skip_styles: Array[Symbol]) -> String
+
+      # Build the style sequences for a segment
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @param segment [Segment] the segment to build style sequences for
+      # @param skip_styles [Array<Symbol>] styles to skip
+      #
+      # @return [Array<String>] the style sequences
+      # @rbs (Segment segment, ?skip_styles: Array[Symbol]) -> Array[String]
+      def build_style_sequences: (Segment segment, ?skip_styles: Array[Symbol]) -> Array[String]
+
+      # A segment of an ANSI encoded string
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api public
+      class Segment
+        # The background color sequences for the Segment
+        #
+        # @author {https://aaronmallen.me Aaron Allen}
+        # @since unreleased
+        #
+        # @api public
+        #
+        # @return [String, nil] the background color sequences
+        attr_reader background: String?
+
+        # The foreground color sequences for the Segment
+        #
+        # @author {https://aaronmallen.me Aaron Allen}
+        # @since unreleased
+        #
+        # @api public
+        #
+        # @return [String, nil] the foreground color sequences
+        attr_reader foreground: String?
+
+        # The {Location} of the encoded string within the {SequencedString}
+        #
+        # @author {https://aaronmallen.me Aaron Allen}
+        # @since unreleased
+        #
+        # @api public
+        #
+        # @return [Location] the {Location}
+        attr_reader encoded_location: Location
+
+        alias encoded_loc encoded_location
+
+        # The {Location} of the encoded string without it's encoding within the {SequencedString}
+        #
+        # @author {https://aaronmallen.me Aaron Allen}
+        # @since unreleased
+        #
+        # @api public
+        #
+        # @return [Location] the {Location}
+        attr_reader stripped_location: Location
+
+        alias stripped_loc stripped_location
+
+        # The style sequences (bold, underline, etc...) for the segment
+        #
+        # @author {https://aaronmallen.me Aaron Allen}
+        # @since unreleased
+        #
+        # @api public
+        #
+        # @return [Array<String>] the style sequences
+        attr_reader styles: Array[String]
+
+        # The raw text of the Segment without any of its ANSI sequences
+        #
+        # @author {https://aaronmallen.me Aaron Allen}
+        # @since unreleased
+        #
+        # @api public
+        #
+        # @return [String]
+        attr_reader text: String
+
+        # Initialize a new instance of Segment
+        #
+        # @author {https://aaronmallen.me Aaron Allen}
+        # @since unreleased
+        #
+        # @api private
+        #
+        # @param options [Hash{Symbol => Object}] the options to initialize the Segment with
+        # @option options background [String, nil] the Segment {#background}
+        # @option options foreground [String, nil] the Segment {#foreground}
+        # @option options encoded_end [Integer] the {Location#end_position end_position} of the Segment
+        #   {#encoded_location}
+        # @option options encoded_start [Integer] the {Location#start_position start_position} of the Segment
+        #   {#encoded_location}
+        # @option options stripped_end [Integer] the {Location#end_position end_position} of the Segment
+        #   {#stripped_location}
+        # @option options stripped_start [Integer] the {Location#start_position start_position} of the Segment
+        #   {#stripped_location}
+        # @option options styles [Array<String>] the Segment {#styles}
+        # @option options text [String] the Segment {#text}
+        #
+        # @return [Segment] the new instance of Segment
+        # @rbs (
+        #   ?background: String?,
+        #   ?foreground: String?,
+        #   encoded_end: Integer,
+        #   encoded_start: Integer,
+        #   stripped_end: Integer,
+        #   stripped_start: Integer,
+        #   ?styles: Array[String],
+        #   text: String
+        #   ) -> void
+        def initialize: (encoded_end: Integer, encoded_start: Integer, stripped_end: Integer, stripped_start: Integer, text: String, ?background: String?, ?foreground: String?, ?styles: Array[String]) -> void
+
+        # The location of the {Segment} within a {SequencedString}
+        #
+        # @author {https://aaronmallen.me Aaron Allen}
+        # @since unreleased
+        #
+        # @api public
+        class Location
+          # The ending position of the Location
+          #
+          # @author {https://aaronmallen.me Aaron Allen}
+          # @since unreleased
+          #
+          # @api public
+          #
+          # @return [Integer] the end position
+          attr_reader end_position: Integer
+
+          alias end_pos end_position
+
+          # The starting position of the Location
+          #
+          # @author {https://aaronmallen.me Aaron Allen}
+          # @since unreleased
+          #
+          # @api public
+          #
+          # @return [Integer] the start position
+          attr_reader start_position: Integer
+
+          alias start_pos start_position
+
+          # Initialize a new instance of Location
+          #
+          # @author {https://aaronmallen.me Aaron Allen}
+          # @since unreleased
+          #
+          # @api private
+          #
+          # @param end_position [Integer] the {#end_position} of the location
+          # @param start_position [Integer] the {#start_position} of the location
+          #
+          # @return [Location] the new instance of Location
+          # @rbs (end_position: Integer, start_position: Integer) -> void
+          def initialize: (end_position: Integer, start_position: Integer) -> void
+        end
+      end
+    end
+  end
+end

--- a/sig/sai/decorator.rbs
+++ b/sig/sai/decorator.rbs
@@ -125,14 +125,13 @@ module Sai
     # @api public
     #
     # @example
-    #   decorator.red.on_blue.bold.decorate('Hello, world!')
-    #   #=> "\e[38;2;205;0;0m\e[48;2;0;0;238m\e[1mHello, world!\e[0m"
+    #   decorator.red.on_blue.bold.decorate('Hello, world!').to_s #=> "\e[38;5;160;48;5;21;1mHello, world!\e[0m"
     #
     # @param text [String] the text to decorate
     #
-    # @return [String] the decorated text
-    # @rbs (String text) -> String
-    def decorate: (String text) -> String
+    # @return [ANSI::SequencedString] the decorated text
+    # @rbs (String text) -> ANSI::SequencedString
+    def decorate: (String text) -> ANSI::SequencedString
 
     alias apply decorate
 
@@ -148,7 +147,7 @@ module Sai
     # @api public
     #
     # @example
-    #   decorator.hex("#EB4133").decorate('Hello, world!') #=> "\e[38;2;235;65;51mHello, world!\e[0m"
+    #   decorator.hex("#EB4133").decorate('Hello, world!').to_s #=> "\e[38;2;235;65;51mHello, world!\e[0m"
     #
     # @param code [String] the hex color code
     #
@@ -165,7 +164,7 @@ module Sai
     # @api public
     #
     # @example
-    #   decorator.on_hex("#EB4133").decorate('Hello, world!') #=> "\e[48;2;235;65;51mHello, world!\e[0m"
+    #   decorator.on_hex("#EB4133").decorate('Hello, world!').to_s #=> "\e[48;2;235;65;51mHello, world!\e[0m"
     #
     # @param code [String] the hex color code
     #
@@ -182,7 +181,7 @@ module Sai
     # @api public
     #
     # @example
-    #   decorator.on_rgb(235, 65, 51).decorate('Hello, world!') #=> "\e[48;2;235;65;51mHello, world!\e[0m"
+    #   decorator.on_rgb(235, 65, 51).decorate('Hello, world!').to_s #=> "\e[48;2;235;65;51mHello, world!\e[0m"
     #
     # @param red [Integer] the red component
     # @param green [Integer] the green component
@@ -201,7 +200,7 @@ module Sai
     # @api public
     #
     # @example
-    #   decorator.rgb(235, 65, 51).decorate('Hello, world!') #=> "\e[38;2;235;65;51mHello, world!\e[0m"
+    #   decorator.rgb(235, 65, 51).decorate('Hello, world!').to_s #=> "\e[38;2;235;65;51mHello, world!\e[0m"
     #
     # @param red [Integer] the red component
     # @param green [Integer] the green component

--- a/spec/sai/ansi/sequence_processor_spec.rb
+++ b/spec/sai/ansi/sequence_processor_spec.rb
@@ -1,0 +1,236 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Sai::ANSI::SequenceProcessor do
+  describe '.process' do
+    subject(:process) { described_class.process(string) }
+
+    context 'when string has no ANSI sequences' do
+      let(:string) { 'Hello, world!' }
+
+      it 'is expected to return an array with a single segment' do
+        expect(process).to contain_exactly(
+          hash_including(
+            foreground: nil,
+            background: nil,
+            styles: [],
+            text: 'Hello, world!',
+            encoded_start: 0,
+            encoded_end: 13,
+            stripped_start: 0,
+            stripped_end: 13
+          )
+        )
+      end
+    end
+
+    context 'when string has a foreground color sequence' do
+      let(:string) { "\e[31mRed text\e[0m" }
+
+      it 'is expected to return an array with a segment containing foreground color' do
+        expect(process).to contain_exactly(
+          hash_including(
+            text: 'Red text',
+            stripped_start: 0,
+            stripped_end: 8
+          )
+        )
+      end
+    end
+
+    context 'when string has a background color sequence' do
+      let(:string) { "\e[41mRed background\e[0m" }
+
+      it 'is expected to return an array with a segment containing background color' do
+        expect(process).to contain_exactly(
+          hash_including(
+            text: 'Red background',
+            stripped_start: 0,
+            stripped_end: 14
+          )
+        )
+      end
+    end
+
+    context 'when string has multiple text segments' do
+      let(:string) { "Normal \e[31mred\e[0m\e[1mbold\e[0m text" }
+      let(:segments) { process }
+
+      it 'is expected to return four segments' do
+        expect(segments.size).to eq(4)
+      end
+
+      it 'is expected to have a plain text segment for "Normal "' do
+        expect(segments[0]).to include(
+          text: 'Normal ',
+          foreground: nil,
+          background: nil,
+          styles: []
+        )
+      end
+
+      it 'is expected to have a red segment for "red"' do
+        expect(segments[1]).to include(
+          text: 'red',
+          foreground: '31',
+          background: nil,
+          styles: []
+        )
+      end
+
+      it 'is expected to have a bold segment for "bold"' do
+        expect(segments[2]).to include(
+          text: 'bold',
+          foreground: nil,
+          background: nil,
+          styles: ['1']
+        )
+      end
+
+      it 'is expected to have a plain text segment for " text"' do
+        expect(segments[3]).to include(
+          text: ' text',
+          foreground: nil,
+          background: nil,
+          styles: []
+        )
+      end
+    end
+
+    context 'when string has extended color codes' do
+      context 'with 256 colors' do
+        let(:string) { "\e[38;5;196mRed 256-color\e[0m" }
+
+        it 'is expected to return a segment with the text content' do
+          expect(process).to contain_exactly(
+            hash_including(
+              text: 'Red 256-color',
+              stripped_start: 0,
+              stripped_end: 13
+            )
+          )
+        end
+      end
+
+      context 'with RGB colors' do
+        let(:string) { "\e[38;2;255;0;0mRGB red\e[0m" }
+
+        it 'is expected to return a segment with the text content' do
+          expect(process).to contain_exactly(
+            hash_including(
+              text: 'RGB red',
+              stripped_start: 0,
+              stripped_end: 7
+            )
+          )
+        end
+      end
+    end
+
+    context 'when using different color modes' do
+      context 'with true color (24-bit) mode' do
+        let(:string) { "\e[38;2;255;0;0m\e[48;2;0;0;255mRGB colors\e[0m" }
+
+        it 'is expected to capture RGB color sequences' do
+          expect(process).to contain_exactly(
+            hash_including(
+              text: 'RGB colors',
+              foreground: '38;2;255;0;0',
+              background: '48;2;0;0;255',
+              styles: []
+            )
+          )
+        end
+      end
+
+      context 'with 256 color (8-bit) mode' do
+        let(:string) { "\e[38;5;196m\e[48;5;21m256 colors\e[0m" }
+
+        it 'is expected to capture 256 color sequences' do
+          expect(process).to contain_exactly(
+            hash_including(
+              text: '256 colors',
+              foreground: '38;5;196',
+              background: '48;5;21',
+              styles: []
+            )
+          )
+        end
+      end
+
+      context 'with 16 color (4-bit) mode' do
+        let(:string) { "\e[31m\e[44mANSI colors\e[0m" }
+
+        it 'is expected to capture ANSI color sequences' do
+          expect(process).to contain_exactly(
+            hash_including(
+              text: 'ANSI colors',
+              foreground: '31',
+              background: '44',
+              styles: []
+            )
+          )
+        end
+      end
+
+      context 'with 8 color (3-bit) mode' do
+        let(:string) { "\e[31m\e[44mBasic colors\e[0m" }
+
+        it 'is expected to capture basic color sequences' do
+          expect(process).to contain_exactly(
+            hash_including(
+              text: 'Basic colors',
+              foreground: '31',
+              background: '44',
+              styles: []
+            )
+          )
+        end
+      end
+    end
+
+    context 'when using multiple style attributes' do
+      let(:string) { "\e[1m\e[3m\e[4mBold, italic and underline\e[0m" }
+
+      it 'is expected to capture all style sequences' do
+        expect(process).to contain_exactly(
+          hash_including(
+            text: 'Bold, italic and underline',
+            foreground: nil,
+            background: nil,
+            styles: %w[1 3 4]
+          )
+        )
+      end
+
+      it 'is expected to maintain style sequence order' do
+        styles = process.first[:styles]
+        expect(styles).to eq(%w[1 3 4])
+      end
+    end
+
+    context 'when using all ANSI styles' do
+      let(:string) do
+        Sai::ANSI::STYLES.reject { |name, _| name.to_s.start_with?('no_') }
+                         .map { |name, code| "\e[#{code}m#{name}\e[0m" }
+                         .join(' ')
+      end
+
+      it 'is expected to capture each style in its own segment' do
+        styles_mapping = Sai::ANSI::STYLES.reject { |name, _| name.to_s.start_with?('no_') }
+                                          .transform_values(&:to_s)
+
+        segments = process.reject { |seg| seg[:text] == ' ' }
+
+        segments.each do |segment|
+          style_name = segment[:text].to_sym
+          expected_styles = [styles_mapping[style_name].to_s]
+          expect(segment[:styles]).to eq(expected_styles),
+                                      "Expected #{segment[:text]} to have styles #{expected_styles}, " \
+                                      "got #{segment[:styles]}"
+        end
+      end
+    end
+  end
+end

--- a/spec/sai/ansi/sequenced_string/segment/location_spec.rb
+++ b/spec/sai/ansi/sequenced_string/segment/location_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Sai::ANSI::SequencedString::Segment::Location do
+  describe '.new' do
+    subject(:location) { described_class.new(end_position: end_pos, start_position: start_pos) }
+
+    let(:end_pos)   { 10 }
+    let(:start_pos) { 3 }
+
+    it 'is expected to set the end_position and start_position' do
+      expect(location).to have_attributes(end_position: 10, start_position: 3)
+    end
+
+    it { is_expected.to be_frozen }
+  end
+end

--- a/spec/sai/ansi/sequenced_string/segment_spec.rb
+++ b/spec/sai/ansi/sequenced_string/segment_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Sai::ANSI::SequencedString::Segment do
+  let(:options) do
+    {
+      background: "\e[44m",
+      foreground: "\e[31m",
+      encoded_end: 10,
+      encoded_start: 5,
+      stripped_end: 7,
+      stripped_start: 3,
+      styles: ["\e[1m"],
+      text: 'hello'
+    }
+  end
+
+  describe '.new' do
+    subject(:segment) { described_class.new(**options) }
+
+    it 'is expected to initialize background, foreground, styles, text, and location info' do
+      expect(segment).to have_attributes(
+        background: "\e[44m",
+        foreground: "\e[31m",
+        styles: contain_exactly("\e[1m"),
+        text: 'hello'
+      )
+    end
+
+    it 'is expected to initialize encoded_location properly' do
+      expect(segment.encoded_location).to have_attributes(
+        start_position: 5,
+        end_position: 10
+      )
+    end
+
+    it 'is expected to initialize stripped_location properly' do
+      expect(segment.stripped_location).to have_attributes(
+        start_position: 3,
+        end_position: 7
+      )
+    end
+
+    it { is_expected.to be_frozen }
+  end
+end

--- a/spec/sai/ansi/sequenced_string_spec.rb
+++ b/spec/sai/ansi/sequenced_string_spec.rb
@@ -1,0 +1,296 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Sai::ANSI::SequencedString do
+  describe '.new' do
+    subject(:sequenced_string) { described_class.new(input) }
+
+    context 'when given an empty string' do
+      let(:input) { '' }
+
+      it 'is expected to create an empty SequencedString' do
+        expect(sequenced_string).to be_empty
+      end
+    end
+
+    context 'when given a plain string (no ANSI codes)' do
+      let(:input) { 'Hello world' }
+
+      it 'is expected to create one segment' do
+        expect(sequenced_string.size).to eq(1)
+      end
+
+      it 'is expected to store the text in the segment' do
+        expect(sequenced_string.first.text).to eq('Hello world')
+      end
+    end
+
+    context 'when given a string with ANSI codes' do
+      let(:input) { "Normal \e[31mred\e[0m" }
+
+      it 'is expected to create multiple segments' do
+        expect(sequenced_string.size).to eq(2)
+      end
+
+      it 'is expected to have a colored segment' do
+        colored_segment = sequenced_string.detect { |seg| seg.foreground == '31' }
+        expect(colored_segment.text).to eq('red')
+      end
+
+      it 'is expected to have a non-colored segment' do
+        plain_segment = sequenced_string.detect { |seg| seg.text == 'Normal ' }
+        expect(plain_segment.foreground).to be_nil
+      end
+    end
+  end
+
+  describe '#[]' do
+    subject(:segment) { sequenced_string[index] }
+
+    let(:sequenced_string) { described_class.new("\e[31mred\e[0m and \e[32mgreen\e[0m") }
+
+    context 'when given a valid index' do
+      let(:index) { 0 }
+
+      it 'is expected to return the segment text at that index' do
+        expect(segment.text).to eq('red')
+      end
+
+      it 'is expected to return the segment foreground at that index' do
+        expect(segment.foreground).to eq('31')
+      end
+    end
+
+    context 'when given an invalid index' do
+      let(:index) { 999 }
+
+      it 'is expected to return nil' do
+        expect(segment).to be_nil
+      end
+    end
+  end
+
+  describe '#==' do
+    subject(:sequence) { described_class.new("\e[31mred\e[0m") }
+
+    context 'when compared to an identical ANSI string' do
+      it 'is expected to be equal' do
+        expect(sequence).to eq("\e[31mred\e[0m")
+      end
+    end
+
+    context 'when compared to a different ANSI string' do
+      it 'is expected to not be equal' do
+        expect(sequence).not_to eq("\e[32mred\e[0m")
+      end
+    end
+
+    context 'when compared to a plain string' do
+      it 'is expected to not be equal' do
+        expect(sequence).not_to eq('red')
+      end
+    end
+  end
+
+  describe '#stripped' do
+    subject(:stripped) { sequenced_string.stripped }
+
+    context 'with a single ANSI code' do
+      let(:sequenced_string) { described_class.new("\e[1mBold\e[0m text") }
+
+      it 'is expected to return the text without ANSI codes' do
+        expect(stripped).to eq('Bold text')
+      end
+    end
+
+    context 'with multiple ANSI codes' do
+      let(:sequenced_string) { described_class.new("\e[31;1mColored Bold\e[0m") }
+
+      it 'is expected to return the text without any ANSI codes' do
+        expect(stripped).to eq('Colored Bold')
+      end
+    end
+  end
+
+  describe '#to_s' do
+    subject(:string) { sequenced_string.to_s }
+
+    context 'with a plain string' do
+      let(:sequenced_string) { described_class.new('Hello') }
+
+      it 'is expected to return the original string' do
+        expect(string).to eq('Hello')
+      end
+    end
+
+    context 'with combined color codes' do
+      let(:sequenced_string) { described_class.new("\e[31;44mColored\e[0m") }
+
+      it 'is expected to maintain combined sequences' do
+        expect(string).to include("\e[31;44mColored\e[0m")
+      end
+    end
+
+    context 'with style and color' do
+      let(:sequenced_string) { described_class.new("\e[31;1mBold Red\e[0m") }
+
+      it 'is expected to maintain combined style and color' do
+        expect(string).to eq("\e[31;1mBold Red\e[0m")
+      end
+    end
+  end
+
+  describe '#without_background' do
+    subject(:without_background) { sequenced_string.without_background }
+
+    let(:sequenced_string) { described_class.new(input) }
+    let(:input) { "\e[31;41mColored BG\e[0m \e[1;31mBold Red\e[0m" }
+
+    it 'is expected to return a SequencedString' do
+      expect(without_background).to be_a(described_class)
+    end
+
+    it 'is expected to return a new instance' do
+      expect(without_background).not_to equal(sequenced_string)
+    end
+
+    it 'is expected to omit background color sequence' do
+      expect(without_background.to_s).not_to include('41')
+    end
+
+    it 'is expected to preserve foreground color sequence' do
+      expect(without_background.to_s).to include('31')
+    end
+
+    it 'is expected to preserve style sequence' do
+      expect(without_background.to_s).to include('1')
+    end
+
+    it 'is expected to be chainable' do
+      expect(without_background.without_style).to be_a(described_class)
+    end
+
+    it 'is expected to maintain correct sequences when chained' do
+      chained = without_background.without_style.to_s
+      expect(chained).to include('31')
+    end
+  end
+
+  describe '#without_color' do
+    subject(:without_color) { sequenced_string.without_color }
+
+    let(:sequenced_string) { described_class.new(input) }
+    let(:input) { "\e[31;42mColored\e[0m \e[1mBold\e[0m" }
+
+    it 'is expected to return a SequencedString' do
+      expect(without_color).to be_a(described_class)
+    end
+
+    it 'is expected to return a new instance' do
+      expect(without_color).not_to equal(sequenced_string)
+    end
+
+    it 'is expected to omit background color sequence' do
+      expect(without_color.to_s).not_to include('42')
+    end
+
+    it 'is expected to omit foreground color sequence' do
+      expect(without_color.to_s).not_to include('31')
+    end
+
+    it 'is expected to preserve style sequence' do
+      expect(without_color.to_s).to include('1')
+    end
+  end
+
+  describe '#without_foreground' do
+    subject(:without_foreground) { sequenced_string.without_foreground }
+
+    let(:sequenced_string) { described_class.new(input) }
+    let(:input) { "\e[31;44mColored\e[0m \e[1mBold\e[0m" }
+
+    it 'is expected to return a SequencedString' do
+      expect(without_foreground).to be_a(described_class)
+    end
+
+    it 'is expected to return a new instance' do
+      expect(without_foreground).not_to equal(sequenced_string)
+    end
+
+    it 'is expected to omit foreground color sequence' do
+      expect(without_foreground.to_s).not_to include('31')
+    end
+
+    it 'is expected to preserve background color sequence' do
+      expect(without_foreground.to_s).to include('44')
+    end
+
+    it 'is expected to preserve style sequence' do
+      expect(without_foreground.to_s).to include('1')
+    end
+  end
+
+  describe '#without_style' do
+    subject(:without_style) { sequenced_string.without_style(*styles) }
+
+    let(:sequenced_string) { described_class.new(input) }
+    let(:input) { "\e[1;4;37mStyled\e[0m" }
+
+    context 'when called with no arguments' do
+      let(:styles) { [] }
+
+      it 'is expected to return a SequencedString' do
+        expect(without_style).to be_a(described_class)
+      end
+
+      it 'is expected to return a new instance' do
+        expect(without_style).not_to equal(sequenced_string)
+      end
+
+      it 'is expected to omit bold style sequence' do
+        expect(without_style.to_s).not_to include('1')
+      end
+
+      it 'is expected to omit underline style sequence' do
+        expect(without_style.to_s).not_to include('4')
+      end
+
+      it 'is expected to preserve color sequence' do
+        expect(without_style.to_s).to include('37')
+      end
+    end
+
+    context 'when called with specific style' do
+      let(:styles) { [:bold] }
+
+      it 'is expected to omit specified style sequence' do
+        expect(without_style.to_s).not_to include('1')
+      end
+
+      it 'is expected to preserve other style sequences' do
+        expect(without_style.to_s).to include('4')
+      end
+
+      it 'is expected to preserve color sequence' do
+        expect(without_style.to_s).to include('37')
+      end
+    end
+
+    context 'when called with multiple styles' do
+      let(:styles) { %i[bold underline] }
+
+      it 'is expected to omit first specified style sequence' do
+        expect(without_style.to_s).not_to include('1')
+      end
+
+      it 'is expected to omit second specified style sequence' do
+        expect(without_style.to_s).not_to include('4')
+      end
+
+      it 'is expected to preserve color sequence' do
+        expect(without_style.to_s).to include('37')
+      end
+    end
+  end
+end

--- a/spec/sai_spec.rb
+++ b/spec/sai_spec.rb
@@ -11,6 +11,14 @@ RSpec.describe Sai do
     it { is_expected.to eq(Sai::ModeSelector) }
   end
 
+  describe '.sequence' do
+    subject(:sequence) { described_class.sequence(text) }
+
+    let(:text) { "\e[31mHello, World!\e[0m" }
+
+    it { is_expected.to be_a(Sai::ANSI::SequencedString) }
+  end
+
   describe '.support' do
     subject(:support) { described_class.support }
 


### PR DESCRIPTION
## Description

This adds powerful ANSI sequence manipulation capabilities to Sai and changes `Decorator#decorate` to return a `SequencedString` instead of a raw string.

## Major Changes

* `Decorator#decorate` now returns `Sai::ANSI::SequencedString` instead of `String`
* Added `Sai.sequence` method to create `SequencedString` from existing ANSI text
* Added comprehensive string manipulation capabilities through `SequencedString`
* Moved detailed documentation to USAGE.md
* Updated contributing guidelines to reflect project maturity

## Examples

```ruby
# Previous behavior:
text = Sai.red.decorate("Hello")  # => String
text.gsub("H", "h")               # works directly

# New behavior:
text = Sai.red.decorate("Hello")  # => Sai::ANSI::SequencedString
text.to_s.gsub("H", "h")         # need explicit conversion for some string ops
puts text                        # works directly with puts/print/etc.

# New sequence manipulation capabilities:
text = Sai.sequence("\e[31mError:\e[0m Details here")
text.without_color               # Keep formatting, remove colors
text.without_style              # Keep colors, remove formatting
text.without_style(:bold)       # Remove specific styles
text.stripped                  # Get plain text

# Access individual segments:
text.each do |segment|
  puts segment.text          # Raw text content
  puts segment.foreground   # Foreground color code
  puts segment.background  # Background color code
  puts segment.styles     # Applied styles
end
```

## Documentation Updates

* Added migration guide: docs/migrations/0.2.0-0.3.0.md
* Created comprehensive usage guide: docs/USAGE.md
* Simplified README.md
* Updated contributing guidelines

## Breaking Changes

The only breaking change is the return type of `Decorator#decorate` (and its aliases `apply`, `call`, and `encode`). While the `SequencedString` class maintains compatibility through `to_s` and `to_str`, some string operations might need explicit conversion.