### PR TITLE
Add color manipulation methods for darkening and lightening colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog], and this project adheres to [Break Ve
 
 ## [Unreleased]
 
+### Added 
+
+* [#8](https://github.com/aaronmallen/sai/pull/8) - Add color manipulation methods for darkening and lightening colors 
+  by [@aaronmallen](https://github.com/aaronmallen)
+
 ## [0.3.0] - 2025-01-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ puts Sai.rgb(255, 128, 0).bold.decorate('Warning: Battery Low')
 puts Sai.hex('#4834d4').italic.decorate('Processing request...')
 puts Sai.bright_cyan.on_blue.underline.decorate('Download Complete!')
 
+# Adjust color brightness
+puts Sai.red.darken_text(0.3).decorate('Subtle Error Message')
+puts Sai.blue.lighten_text(0.5).decorate('Highlighted Info')
+
 # Analyze and manipulate ANSI-encoded text
 text = Sai.sequence("\e[31mError:\e[0m Connection failed")
 puts text.without_color  # Keep formatting, remove colors
@@ -65,6 +69,10 @@ puts Sai.bright_blue.on_white.decorate('Info')
 # Using RGB colors
 puts Sai.rgb(255, 128, 0).decorate('Custom color')
 puts Sai.on_rgb(0, 255, 128).decorate('Custom background')
+
+# Color manipulation
+puts Sai.blue.lighten_text(0.5).decorate('Lightened blue')
+puts Sai.red.darken_text(0.3).decorate('Darkened red')
 
 # Applying styles
 puts Sai.bold.underline.decorate('Important')

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -97,6 +97,19 @@ Available named colors:
 > While named colors provide convenient shortcuts, remember that Sai supports the full RGB color space. Don't feel
 > limited to just these predefined colors!
 
+### Color Manipulation
+
+Adjust the brightness of colors:
+
+```ruby
+# Darken colors
+Sai.red.darken_text(0.5).decorate('Darkened red text')
+Sai.on_blue.darken_background(0.3).decorate('Darkened blue background')
+
+# Lighten colors
+Sai.blue.lighten_text(0.5).decorate('Lightened blue text')
+Sai.on_red.lighten_background(0.3).decorate('Lightened red background')
+
 ## Text Styles
 
 Sai supports a variety of text styles:
@@ -286,6 +299,7 @@ end
   * Use named colors for standard indicators (red for errors, etc.)
   * Use RGB/Hex for brand colors or specific design requirements
   * Consider color blindness when choosing colors
+  * Use `darken_text`/`lighten_text` to create visual hierarchy or emphasis
 
 3. **Style Organization**
   * Create reusable styles for consistency

--- a/lib/sai/conversion/rgb.rb
+++ b/lib/sai/conversion/rgb.rb
@@ -51,6 +51,26 @@ module Sai
           [red, green, blue].max < 0.3
         end
 
+        # Darken an RGB color by a percentage
+        #
+        # @author {https://aaronmallen.me Aaron Allen}
+        # @since unreleased
+        #
+        # @api private
+        #
+        # @param color [Array<Integer>, String, Symbol] the color to darken
+        # @param amount [Float] amount to darken by (0.0-1.0)
+        #
+        # @raise [ArgumentError] if amount is not between 0.0 and 1.0
+        # @return [Array<Integer>] the darkened RGB values
+        # @rbs ((Array[Integer] | String | Symbol) color, Float amount) -> Array[Integer]
+        def darken(color, amount)
+          raise ArgumentError, "Invalid amount: #{amount}" unless amount.between?(0.0, 1.0)
+
+          rgb = resolve(color)
+          rgb.map { |c| [0, (c * (1 - amount)).round].max }
+        end
+
         # Determine if a color is grayscale
         #
         # @author {https://aaronmallen.me Aaron Allen}
@@ -66,6 +86,26 @@ module Sai
         # @rbs (Float red, Float green, Float blue) -> bool
         def grayscale?(red, green, blue)
           red == green && green == blue
+        end
+
+        # Lighten an RGB color by a percentage
+        #
+        # @author {https://aaronmallen.me Aaron Allen}
+        # @since unreleased
+        #
+        # @api private
+        #
+        # @param color [Array<Integer>, String, Symbol] the color to lighten
+        # @param amount [Float] amount to lighten by (0.0-1.0)
+        #
+        # @raise [ArgumentError] if amount is not between 0.0 and 1.0
+        # @return [Array<Integer>] the lightened RGB values
+        # @rbs ((Array[Integer] | String | Symbol) color, Float amount) -> Array[Integer]
+        def lighten(color, amount)
+          raise ArgumentError, "Invalid amount: #{amount}" unless amount.between?(0.0, 1.0)
+
+          rgb = resolve(color)
+          rgb.map { |c| [255, (c * (1 + amount)).round].min }
         end
 
         # Convert a color value to RGB components

--- a/sig/sai/conversion/rgb.rbs
+++ b/sig/sai/conversion/rgb.rbs
@@ -39,6 +39,21 @@ module Sai
       # @rbs (Float red, Float green, Float blue) -> bool
       def self.dark?: (Float red, Float green, Float blue) -> bool
 
+      # Darken an RGB color by a percentage
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @param color [Array<Integer>, String, Symbol] the color to darken
+      # @param amount [Float] amount to darken by (0.0-1.0)
+      #
+      # @raise [ArgumentError] if amount is not between 0.0 and 1.0
+      # @return [Array<Integer>] the darkened RGB values
+      # @rbs ((Array[Integer] | String | Symbol) color, Float amount) -> Array[Integer]
+      def self.darken: (Array[Integer] | String | Symbol color, Float amount) -> Array[Integer]
+
       # Determine if a color is grayscale
       #
       # @author {https://aaronmallen.me Aaron Allen}
@@ -53,6 +68,21 @@ module Sai
       # @return [Boolean] true if color is grayscale
       # @rbs (Float red, Float green, Float blue) -> bool
       def self.grayscale?: (Float red, Float green, Float blue) -> bool
+
+      # Lighten an RGB color by a percentage
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @param color [Array<Integer>, String, Symbol] the color to lighten
+      # @param amount [Float] amount to lighten by (0.0-1.0)
+      #
+      # @raise [ArgumentError] if amount is not between 0.0 and 1.0
+      # @return [Array<Integer>] the lightened RGB values
+      # @rbs ((Array[Integer] | String | Symbol) color, Float amount) -> Array[Integer]
+      def self.lighten: (Array[Integer] | String | Symbol color, Float amount) -> Array[Integer]
 
       # Convert a color value to RGB components
       #

--- a/sig/sai/decorator.rbs
+++ b/sig/sai/decorator.rbs
@@ -117,6 +117,46 @@ module Sai
 
     def underline: () -> Decorator
 
+    # Darken the background color by a percentage
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api public
+    #
+    # @example
+    #   decorator.on_blue.darken_text(0.5).decorate('Hello, world!').to_s #=> "\e[48;2;0;0;238mHello, world!\e[0m"
+    #
+    # @param amount [Float] the amount to darken the background color (0.0...1.0)
+    #
+    # @raise [ArgumentError] if the percentage is out of range
+    # @return [Decorator] a new instance of Decorator with the darkened background color
+    # @rbs (Float amount) -> Decorator
+    def darken_background: (Float amount) -> Decorator
+
+    alias darken_bg darken_background
+
+    # Darken the text color by a percentage
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api public
+    #
+    # @example
+    #   decorator.blue.darken_text(0.5).decorate('Hello, world!').to_s #=> "\e[38;2;0;0;119mHello, world!\e[0m"
+    #
+    # @param amount [Float] the amount to darken the text color (0.0...1.0)
+    #
+    # @raise [ArgumentError] if the percentage is out of range
+    # @return [Decorator] a new instance of Decorator with the darkened text color
+    # @rbs (Float amount) -> Decorator
+    def darken_text: (Float amount) -> Decorator
+
+    alias darken_fg darken_text
+
+    alias darken_foreground darken_text
+
     # Apply the styles and colors to the text
     #
     # @author {https://aaronmallen.me Aaron Allen}
@@ -155,6 +195,47 @@ module Sai
     # @return [Decorator] a new instance of Decorator with the hex color applied
     # @rbs (String code) -> Decorator
     def hex: (String code) -> Decorator
+
+    # Lighten the background color by a percentage
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api public
+    #
+    # @example
+    #   decorator.on_blue.lighten_background(0.5).decorate('Hello, world!').to_s
+    #   #=> "\e[48;2;0;0;255mHello, world!\e[0m"
+    #
+    # @param amount [Float] the amount to lighten the background color (0.0...1.0)
+    #
+    # @raise [ArgumentError] if the percentage is out of range
+    # @return [Decorator] a new instance of Decorator with the lightened background color
+    # @rbs (Float amount) -> Decorator
+    def lighten_background: (Float amount) -> Decorator
+
+    alias lighten_bg lighten_background
+
+    # Lighten the text color by a percentage
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api public
+    #
+    # @example
+    #   decorator.blue.lighten_text(0.5).decorate('Hello, world!').to_s #=> "\e[38;2;0;0;127mHello, world!\e[0m"
+    #
+    # @param amount [Float] the amount to lighten the text color (0.0...1.0)
+    #
+    # @raise [ArgumentError] if the percentage is out of range
+    # @return [Decorator] a new instance of Decorator with the lightened text color
+    # @rbs (Float amount) -> Decorator
+    def lighten_text: (Float amount) -> Decorator
+
+    alias lighten_fg lighten_text
+
+    alias lighten_foreground lighten_text
 
     # Apply a hexadecimal color to the background
     #
@@ -255,6 +336,34 @@ module Sai
     # @return [Decorator] a new instance of Decorator with the style applied
     # @rbs (String | Symbol style) -> self
     def apply_style: (String | Symbol style) -> self
+
+    # Darken the foreground or background color by a specified amount
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api private
+    #
+    # @param amount [Float] a value between 0.0 and 1.0 to darken the color by
+    # @param component [Symbol] the color component to darken
+    #
+    # @return [Decorator] a new instance of Decorator with the color darkened
+    # @rbs (Float amount, Symbol component) -> Decorator
+    def darken: (Float amount, Symbol component) -> Decorator
+
+    # Lighten the foreground or background color by a specified amount
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api private
+    #
+    # @param amount [Float] a value between 0.0 and 1.0 to lighten the color by
+    # @param component [Symbol] the color component to lighten
+    #
+    # @return [Decorator] a new instance of Decorator with the color lightened
+    # @rbs (Float amount, Symbol component) -> Decorator
+    def lighten: (Float amount, Symbol component) -> Decorator
 
     # Check if text should be decorated
     #

--- a/spec/sai/conversion/rgb_spec.rb
+++ b/spec/sai/conversion/rgb_spec.rb
@@ -83,6 +83,128 @@ RSpec.describe Sai::Conversion::RGB do
     end
   end
 
+  describe '.darken' do
+    subject(:darken) { described_class.darken(color, amount) }
+
+    context 'when given an RGB array' do
+      let(:color) { [255, 128, 64] }
+      let(:amount) { 0.5 }
+
+      it 'is expected to darken the color by the specified amount' do
+        expect(darken).to eq([128, 64, 32])
+      end
+
+      context 'when amount would make values negative' do
+        let(:amount) { 1.0 }
+
+        it 'is expected to clamp values at 0' do
+          expect(darken).to eq([0, 0, 0])
+        end
+      end
+    end
+
+    context 'when given a hex color' do
+      let(:color) { '#FF8040' }
+      let(:amount) { 0.5 }
+
+      it 'is expected to darken the color by the specified amount' do
+        expect(darken).to eq([128, 64, 32])
+      end
+    end
+
+    context 'when given a named color' do
+      let(:color) { :red }
+      let(:amount) { 0.5 }
+
+      it 'is expected to darken the color by the specified amount' do
+        rgb = Sai::ANSI::COLOR_NAMES[:red]
+        expected = rgb.map { |c| (c * 0.5).round }
+        expect(darken).to eq(expected)
+      end
+    end
+
+    context 'when given an invalid amount' do
+      let(:color) { [255, 128, 64] }
+
+      context 'when amount is negative' do
+        let(:amount) { -0.5 }
+
+        it 'is expected to raise ArgumentError' do
+          expect { darken }.to raise_error(ArgumentError, /Invalid amount/)
+        end
+      end
+
+      context 'when amount is greater than 1.0' do
+        let(:amount) { 1.5 }
+
+        it 'is expected to raise ArgumentError' do
+          expect { darken }.to raise_error(ArgumentError, /Invalid amount/)
+        end
+      end
+    end
+  end
+
+  describe '.lighten' do
+    subject(:lighten) { described_class.lighten(color, amount) }
+
+    context 'when given an RGB array' do
+      let(:color) { [128, 64, 32] }
+      let(:amount) { 0.5 }
+
+      it 'is expected to lighten the color by the specified amount' do
+        expect(lighten).to eq([192, 96, 48])
+      end
+
+      context 'when amount would exceed 255' do
+        let(:amount) { 1.0 }
+
+        it 'is expected to clamp values at 255' do
+          expect(lighten).to eq([255, 128, 64])
+        end
+      end
+    end
+
+    context 'when given a hex color' do
+      let(:color) { '#804020' }
+      let(:amount) { 0.5 }
+
+      it 'is expected to lighten the color by the specified amount' do
+        expect(lighten).to eq([192, 96, 48])
+      end
+    end
+
+    context 'when given a named color' do
+      let(:color) { :blue }
+      let(:amount) { 0.5 }
+
+      it 'is expected to lighten the color by the specified amount' do
+        rgb = Sai::ANSI::COLOR_NAMES[:blue]
+        expected = rgb.map { |c| [255, (c * 1.5).round].min }
+        expect(lighten).to eq(expected)
+      end
+    end
+
+    context 'when given an invalid amount' do
+      let(:color) { [128, 64, 32] }
+
+      context 'when amount is negative' do
+        let(:amount) { -0.5 }
+
+        it 'is expected to raise ArgumentError' do
+          expect { lighten }.to raise_error(ArgumentError, /Invalid amount/)
+        end
+      end
+
+      context 'when amount is greater than 1.0' do
+        let(:amount) { 1.5 }
+
+        it 'is expected to raise ArgumentError' do
+          expect { lighten }.to raise_error(ArgumentError, /Invalid amount/)
+        end
+      end
+    end
+  end
+
   describe '.resolve' do
     subject(:resolve) { described_class.resolve(color) }
 

--- a/spec/sai/decorator_spec.rb
+++ b/spec/sai/decorator_spec.rb
@@ -25,6 +25,92 @@ RSpec.describe Sai::Decorator do
     end
   end
 
+  describe '#darken_background' do
+    subject(:darken_background) { decorator.darken_background(amount) }
+
+    let(:decorator) { described_class.new(mode: mode).on_blue }
+    let(:mode) { Sai::Terminal::ColorMode::TRUE_COLOR }
+    let(:amount) { 0.5 }
+
+    it { is_expected.to be_an_instance_of(described_class) }
+
+    it 'is expected to return a new instance' do
+      expect(darken_background).not_to eq(decorator)
+    end
+
+    it 'is expected to set the darkened background color on the new instance' do
+      rgb = Sai::ANSI::COLOR_NAMES[:blue].map { |c| (c * 0.5).round }
+      expect(darken_background.instance_variable_get(:@background)).to eq(rgb)
+    end
+
+    it 'is expected not to modify the original instance' do
+      original_background = decorator.instance_variable_get(:@background)
+      darken_background
+      expect(decorator.instance_variable_get(:@background)).to eq(original_background)
+    end
+
+    context 'when given an invalid amount' do
+      context 'when amount is negative' do
+        let(:amount) { -0.5 }
+
+        it 'is expected to raise ArgumentError' do
+          expect { darken_background }.to raise_error(ArgumentError, /Invalid percentage/)
+        end
+      end
+
+      context 'when amount is greater than 1.0' do
+        let(:amount) { 1.5 }
+
+        it 'is expected to raise ArgumentError' do
+          expect { darken_background }.to raise_error(ArgumentError, /Invalid percentage/)
+        end
+      end
+    end
+  end
+
+  describe '#darken_text' do
+    subject(:darken_text) { decorator.darken_text(amount) }
+
+    let(:decorator) { described_class.new(mode: mode).red }
+    let(:mode) { Sai::Terminal::ColorMode::TRUE_COLOR }
+    let(:amount) { 0.5 }
+
+    it { is_expected.to be_an_instance_of(described_class) }
+
+    it 'is expected to return a new instance' do
+      expect(darken_text).not_to eq(decorator)
+    end
+
+    it 'is expected to set the darkened foreground color on the new instance' do
+      rgb = Sai::ANSI::COLOR_NAMES[:red].map { |c| (c * 0.5).round }
+      expect(darken_text.instance_variable_get(:@foreground)).to eq(rgb)
+    end
+
+    it 'is expected not to modify the original instance' do
+      original_foreground = decorator.instance_variable_get(:@foreground)
+      darken_text
+      expect(decorator.instance_variable_get(:@foreground)).to eq(original_foreground)
+    end
+
+    context 'when given an invalid amount' do
+      context 'when amount is negative' do
+        let(:amount) { -0.5 }
+
+        it 'is expected to raise ArgumentError' do
+          expect { darken_text }.to raise_error(ArgumentError, /Invalid percentage/)
+        end
+      end
+
+      context 'when amount is greater than 1.0' do
+        let(:amount) { 1.5 }
+
+        it 'is expected to raise ArgumentError' do
+          expect { darken_text }.to raise_error(ArgumentError, /Invalid percentage/)
+        end
+      end
+    end
+  end
+
   describe '#decorate' do
     subject(:decorated_text) { decorator.decorate(text) }
 
@@ -102,6 +188,92 @@ RSpec.describe Sai::Decorator do
 
       it 'is expected to raise an ArgumentError' do
         expect { hex_decorator }.to raise_error(ArgumentError, 'Invalid hex color code: invalid')
+      end
+    end
+  end
+
+  describe '#lighten_background' do
+    subject(:lighten_background) { decorator.lighten_background(amount) }
+
+    let(:decorator) { described_class.new(mode: mode).on_red }
+    let(:mode) { Sai::Terminal::ColorMode::TRUE_COLOR }
+    let(:amount) { 0.5 }
+
+    it { is_expected.to be_an_instance_of(described_class) }
+
+    it 'is expected to return a new instance' do
+      expect(lighten_background).not_to eq(decorator)
+    end
+
+    it 'is expected to set the lightened background color on the new instance' do
+      rgb = Sai::ANSI::COLOR_NAMES[:red].map { |c| [255, (c * 1.5).round].min }
+      expect(lighten_background.instance_variable_get(:@background)).to eq(rgb)
+    end
+
+    it 'is expected not to modify the original instance' do
+      original_background = decorator.instance_variable_get(:@background)
+      lighten_background
+      expect(decorator.instance_variable_get(:@background)).to eq(original_background)
+    end
+
+    context 'when given an invalid amount' do
+      context 'when amount is negative' do
+        let(:amount) { -0.5 }
+
+        it 'is expected to raise ArgumentError' do
+          expect { lighten_background }.to raise_error(ArgumentError, /Invalid percentage/)
+        end
+      end
+
+      context 'when amount is greater than 1.0' do
+        let(:amount) { 1.5 }
+
+        it 'is expected to raise ArgumentError' do
+          expect { lighten_background }.to raise_error(ArgumentError, /Invalid percentage/)
+        end
+      end
+    end
+  end
+
+  describe '#lighten_text' do
+    subject(:lighten_text) { decorator.lighten_text(amount) }
+
+    let(:decorator) { described_class.new(mode: mode).blue }
+    let(:mode) { Sai::Terminal::ColorMode::TRUE_COLOR }
+    let(:amount) { 0.5 }
+
+    it { is_expected.to be_an_instance_of(described_class) }
+
+    it 'is expected to return a new instance' do
+      expect(lighten_text).not_to eq(decorator)
+    end
+
+    it 'is expected to set the lightened foreground color on the new instance' do
+      rgb = Sai::ANSI::COLOR_NAMES[:blue].map { |c| [255, (c * 1.5).round].min }
+      expect(lighten_text.instance_variable_get(:@foreground)).to eq(rgb)
+    end
+
+    it 'is expected not to modify the original instance' do
+      original_foreground = decorator.instance_variable_get(:@foreground)
+      lighten_text
+      expect(decorator.instance_variable_get(:@foreground)).to eq(original_foreground)
+    end
+
+    context 'when given an invalid amount' do
+      context 'when amount is negative' do
+        let(:amount) { -0.5 }
+
+        it 'is expected to raise ArgumentError' do
+          expect { lighten_text }.to raise_error(ArgumentError, /Invalid percentage/)
+        end
+      end
+
+      context 'when amount is greater than 1.0' do
+        let(:amount) { 1.5 }
+
+        it 'is expected to raise ArgumentError' do
+          expect { lighten_text }.to raise_error(ArgumentError, /Invalid percentage/)
+        end
       end
     end
   end


### PR DESCRIPTION
This adds methods to manipulate color brightness in both foreground and text colors.

## New methods

* `darken_text(amount)` / `darken_foreground(amount)` / `darken_fg(amount)` - Darken text color
* `darken_background(amount)` / `darken_bg(amount)` - Darken background color 
* `lighten_text(amount)` / `lighten_foreground(amount)` / `lighten_fg(amount)` - Lighten text color
* `lighten_background(amount)` / `lighten_bg(amount)` - Lighten background color

The amount parameter accepts values between 0.0 and 1.0 where:

* 0.0 = no change
* 1.0 = maximum darkening/lightening

Examples:

```ruby
# Darken text colors
Sai.red.darken_text(0.5).decorate('Darker red text')
Sai.blue.darken_foreground(0.3).decorate('Slightly darker blue')

# Darken backgrounds
Sai.on_green.darken_background(0.5).decorate('Darker green background')
Sai.on_yellow.darken_bg(0.3).decorate('Slightly darker yellow background')

# Lighten text colors
Sai.blue.lighten_text(0.5).decorate('Lighter blue text') 
Sai.red.lighten_foreground(0.3).decorate('Slightly lighter red')

# Lighten backgrounds
Sai.on_blue.lighten_background(0.5).decorate('Lighter blue background')
Sai.on_red.lighten_bg(0.3).decorate('Slightly lighter red background')
```

The implementation

* Works with RGB, hex, and named colors
* Preserves original color mode and style settings
* Clamps values appropriately (0-255 for RGB)
* Includes full test coverage
* Updates documentation

This feature allows for more sophisticated color usage in terminal UIs by enabling fine-grained control over color brightness.