### PR TITLE
Add gradient and rainbow color effects for text and backgrounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog], and this project adheres to [Break Ve
 
 * [#8](https://github.com/aaronmallen/sai/pull/8) - Add color manipulation methods for darkening and lightening colors 
   by [@aaronmallen](https://github.com/aaronmallen)
+* [#9](https://github.com/aaronmallen/sai/pull/9) - Add gradient and rainbow color effects for text and backgrounds by
+  [@aaronmallen](https://github.com/aaronmallen)
 
 ## [0.3.0] - 2025-01-20
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -9,6 +9,8 @@ This guide provides comprehensive documentation for using Sai in your applicatio
   * [RGB Colors](#rgb-colors)
   * [Hex Colors](#hex-colors)
   * [Named Colors](#named-colors)
+  * [Color Manipulation](#color-manipulation)
+  * [Gradient and Rainbow Effects](#gradient-and-rainbow-effects)
 * [Text Styles](#text-styles)
 * [ANSI Sequence Manipulation](#ansi-sequence-manipulation)
 * [Color Mode Management](#color-mode-management)
@@ -109,6 +111,30 @@ Sai.on_blue.darken_background(0.3).decorate('Darkened blue background')
 # Lighten colors
 Sai.blue.lighten_text(0.5).decorate('Lightened blue text')
 Sai.on_red.lighten_background(0.3).decorate('Lightened red background')
+```
+
+### Gradient and Rainbow Effects
+
+Create dynamic color transitions across text:
+
+```ruby
+# Text gradients (foreground)
+Sai.gradient('#000000', '#FFFFFF', 5).decorate('Black to white gradient')
+Sai.gradient(:red, :blue, 10).decorate('Red to blue gradient')
+Sai.rainbow(6).decorate('Rainbow text')
+
+# Background gradients
+Sai.on_gradient('#FF0000', '#0000FF', 8).decorate('Red to blue background')
+Sai.on_gradient(:yellow, :green, 5).decorate('Yellow to green background')
+Sai.on_rainbow(6).decorate('Rainbow background')
+```
+
+Gradients can use any combination of color formats (hex, RGB, or named colors) and will automatically adjust to fit your
+text length. Spaces in text are preserved without color effects.
+
+> [!TIP]
+> The number of gradient steps affects the smoothness of the transition. More steps create smoother gradients, but
+> consider terminal performance for very long text.
 
 ## Text Styles
 

--- a/lib/sai/decorator.rb
+++ b/lib/sai/decorator.rb
@@ -27,8 +27,10 @@ module Sai
     # @rbs (?mode: Integer) -> void
     def initialize(mode: Sai.mode.auto)
       @background = nil
+      @background_sequence = nil
       @mode = mode
       @foreground = nil
+      @foreground_sequence = nil
       @styles = [] #: Array[Symbol]
     end
 
@@ -742,6 +744,7 @@ module Sai
     # @rbs (String text) -> ANSI::SequencedString
     def decorate(text)
       return ANSI::SequencedString.new(text) unless should_decorate?
+      return apply_sequence_gradient(text) if @foreground_sequence || @background_sequence
 
       sequences = [
         @foreground && Conversion::ColorSequence.resolve(@foreground, @mode),
@@ -754,6 +757,33 @@ module Sai
     alias apply decorate
     alias call decorate
     alias encode decorate
+
+    # Build a foreground gradient between two colors for text decoration
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api public
+    #
+    # @example Create a foreground gradient from red to blue
+    #   decorator.gradient(:red, :blue, 10).decorate('Hello, World!')
+    #   #=> "\e[38;2;255;0;0mH\e[0m\e[38;2;204;0;51me\e[0m..."
+    #
+    # @param start_color [Array<Integer>, String, Symbol] the starting color
+    # @param end_color [Array<Integer>, String, Symbol] the ending color
+    # @param steps [Integer] the number of gradient steps (minimum 2)
+    #
+    # @raise [ArgumentError] if steps is less than 2
+    # @return [Decorator] a new instance of Decorator with foreground gradient colors
+    # @rbs (
+    #   Array[Integer] | String | Symbol start_color,
+    #   Array[Integer] | String | Symbol end_color,
+    #   Integer steps
+    #   ) -> Decorator
+    def gradient(start_color, end_color, steps)
+      colors = Conversion::RGB.gradient(start_color, end_color, steps)
+      dup.tap { |duped| duped.instance_variable_set(:@foreground_sequence, colors) }
+    end
 
     # Apply a hexadecimal color to the foreground
     #
@@ -822,6 +852,33 @@ module Sai
     alias lighten_fg lighten_text
     alias lighten_foreground lighten_text
 
+    # Build a background gradient between two colors for text decoration
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api public
+    #
+    # @example Create a background gradient from red to blue
+    #   decorator.on_gradient(:red, :blue, 10).decorate('Hello, World!')
+    #   #=> "\e[48;2;255;0;0mH\e[0m\e[48;2;204;0;51me\e[0m..."
+    #
+    # @param start_color [Array<Integer>, String, Symbol] the starting color
+    # @param end_color [Array<Integer>, String, Symbol] the ending color
+    # @param steps [Integer] the number of gradient steps (minimum 2)
+    #
+    # @raise [ArgumentError] if steps is less than 2
+    # @return [Decorator] a new instance of Decorator with background gradient colors
+    # @rbs (
+    #   Array[Integer] | String | Symbol start_color,
+    #   Array[Integer] | String | Symbol end_color,
+    #   Integer steps
+    #   ) -> Decorator
+    def on_gradient(start_color, end_color, steps)
+      colors = Conversion::RGB.gradient(start_color, end_color, steps)
+      dup.tap { |duped| duped.instance_variable_set(:@background_sequence, colors) }
+    end
+
     # Apply a hexadecimal color to the background
     #
     # @author {https://aaronmallen.me Aaron Allen}
@@ -841,6 +898,27 @@ module Sai
       raise ArgumentError, "Invalid hex color code: #{code}" unless /^#?([A-Fa-f0-9]{6})$/.match?(code)
 
       dup.tap { |duped| duped.instance_variable_set(:@background, code) }
+    end
+
+    # Build a background rainbow gradient for text decoration
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api public
+    #
+    # @example Create a rainbow background gradient
+    #   decorator.on_rainbow(6).decorate('Hello, World!')
+    #   #=> "\e[48;2;255;0;0mH\e[0m\e[48;2;255;255;0me\e[0m..."
+    #
+    # @param steps [Integer] the number of colors to generate (minimum 2)
+    #
+    # @raise [ArgumentError] if steps is less than 2
+    # @return [Decorator] a new instance of Decorator with background rainbow colors
+    # @rbs (Integer steps) -> Decorator
+    def on_rainbow(steps)
+      colors = Conversion::RGB.rainbow_gradient(steps)
+      dup.tap { |duped| duped.instance_variable_set(:@background_sequence, colors) }
     end
 
     # Apply an RGB color to the background
@@ -866,6 +944,27 @@ module Sai
       end
 
       dup.tap { |duped| duped.instance_variable_set(:@background, [red, green, blue]) }
+    end
+
+    # Build a foreground rainbow gradient for text decoration
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api public
+    #
+    # @example Create a rainbow text gradient
+    #   decorator.rainbow(6).decorate('Hello, World!')
+    #   #=> "\e[38;2;255;0;0mH\e[0m\e[38;2;255;255;0me\e[0m..."
+    #
+    # @param steps [Integer] the number of colors to generate (minimum 2)
+    #
+    # @raise [ArgumentError] if steps is less than 2
+    # @return [Decorator] a new instance of Decorator with foreground rainbow colors
+    # @rbs (Integer steps) -> Decorator
+    def rainbow(steps)
+      colors = Conversion::RGB.rainbow_gradient(steps)
+      dup.tap { |duped| duped.instance_variable_set(:@foreground_sequence, colors) }
     end
 
     # Apply an RGB color to the foreground
@@ -913,6 +1012,25 @@ module Sai
 
     private
 
+    # Adjust number of colors to match text length
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api private
+    #
+    # @param colors [Array<Array<Integer>>] original color sequence
+    # @param text_length [Integer] desired number of colors
+    #
+    # @return [Array<Array<Integer>>] adjusted color sequence
+    # @rbs (Array[Array[Integer]] colors, Integer text_length) -> Array[Array[Integer]]
+    def adjust_colors_to_text_length(colors, text_length)
+      return colors if colors.length == text_length
+      return stretch_colors(colors, text_length) if colors.length < text_length
+
+      shrink_colors(colors, text_length)
+    end
+
     # Apply a named color to the specified style type
     #
     # @author {https://aaronmallen.me Aaron Allen}
@@ -929,6 +1047,27 @@ module Sai
       dup.tap { |duped| duped.instance_variable_set(:"@#{style_type}", color) }
     end
 
+    # Apply color sequence gradients to text
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api private
+    #
+    # @param text [String] the text to apply the gradient to
+    #
+    # @return [ANSI::SequencedString] the text with gradient applied
+    # @rbs (String text) -> ANSI::SequencedString
+    def apply_sequence_gradient(text)
+      return ANSI::SequencedString.new(text) unless should_decorate?
+
+      chars = text.chars
+      adjusted_colors = prepare_color_sequences(chars.length)
+      gradient_text = build_gradient_text(chars, adjusted_colors)
+
+      ANSI::SequencedString.new(gradient_text.join)
+    end
+
     # Apply a style to the text
     #
     # @author {https://aaronmallen.me Aaron Allen}
@@ -943,6 +1082,69 @@ module Sai
     def apply_style(style)
       style = style.to_s.downcase.to_sym
       dup.tap { |duped| duped.instance_variable_set(:@styles, (@styles + [style]).uniq) }
+    end
+
+    # Build color sequences for a single character
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api private
+    #
+    # @param colors [Hash] color sequences for foreground and background
+    # @param index [Integer] character position
+    #
+    # @return [Array<String>] ANSI sequences for the character
+    # @rbs (Hash[Symbol, Array[Array[Integer]]] colors, Integer index) -> Array[String]
+    def build_color_sequences(colors, index)
+      sequences = []
+      sequences << get_foreground_sequence(colors[:foreground], index) if colors[:foreground]
+      sequences << get_background_sequence(colors[:background], index) if colors[:background]
+      sequences += style_sequences
+      sequences.compact
+    end
+
+    # Build gradient text from characters and color sequences
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api private
+    #
+    # @param chars [Array<String>] text characters
+    # @param colors [Hash] color sequences for foreground and background
+    #
+    # @return [Array<String>] colored characters
+    # @rbs (Array[String] chars, Hash[Symbol, Array[Array[Integer]]] colors) -> Array[String]
+    def build_gradient_text(chars, colors)
+      chars.each_with_index.map do |char, i|
+        next char if char == ' '
+
+        sequences = build_color_sequences(colors, i)
+        "#{sequences.join}#{char}#{ANSI::RESET}"
+      end
+    end
+
+    # Calculate indices and progress for color interpolation
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api private
+    #
+    # @param position [Integer] current position in sequence
+    # @param step_size [Float] size of each step
+    # @param max_index [Integer] maximum index allowed
+    #
+    # @return [Hash] interpolation indices and progress
+    # @rbs (Integer position, Float step_size, Integer max_index) -> Hash[Symbol, Integer | Float]
+    def calculate_interpolation_indices(position, step_size, max_index)
+      position_in_sequence = position * step_size
+      lower = position_in_sequence.floor
+      upper = [lower + 1, max_index - 1].min
+      progress = position_in_sequence - lower
+
+      { lower: lower, upper: upper, progress: progress }
     end
 
     # Darken the foreground or background color by a specified amount
@@ -965,6 +1167,76 @@ module Sai
           rgb = Conversion::RGB.darken(color, amount)
           duped.instance_variable_set(:"@#{component}", rgb)
         end
+      end
+    end
+
+    # Get background sequence for a character
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api private
+    #
+    # @param colors [Array<Array<Integer>>, nil] background color sequence
+    # @param index [Integer] character position
+    #
+    # @return [String, nil] ANSI sequence for background
+    # @rbs (Array[Array[Integer]]? colors, Integer index) -> String?
+    def get_background_sequence(colors, index)
+      if colors
+        Conversion::ColorSequence.resolve(colors[index], @mode, :background)
+      elsif @background_sequence
+        Conversion::ColorSequence.resolve(@background_sequence[index], @mode, :background)
+      end
+    end
+
+    # Get foreground sequence for a character
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api private
+    #
+    # @param colors [Array<Array<Integer>>, nil] foreground color sequence
+    # @param index [Integer] character position
+    #
+    # @return [String, nil] ANSI sequence for foreground
+    # @rbs (Array[Array[Integer]]? colors, Integer index) -> String?
+    def get_foreground_sequence(colors, index)
+      if colors
+        Conversion::ColorSequence.resolve(colors[index], @mode)
+      elsif @foreground_sequence
+        Conversion::ColorSequence.resolve(@foreground_sequence[index], @mode)
+      end
+    end
+
+    # Interpolate between two colors in a sequence
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api private
+    #
+    # @param colors [Array<Array<Integer>>] color sequence
+    # @param indices [Hash] interpolation indices and progress
+    #
+    # @return [Array<Integer>] interpolated color
+    # @rbs (Array[Array[Integer]] colors, Hash[Symbol, Integer | Float]) -> Array[Integer]
+    def interpolate_sequence_colors(colors, indices)
+      lower_index = indices[:lower].to_i
+      upper_index = indices[:upper].to_i
+      progress = indices[:progress].to_f
+
+      color1 = colors[lower_index]
+      color2 = colors[upper_index]
+
+      # Add nil guards
+      return [0, 0, 0] unless color1 && color2
+
+      color1.zip(color2).map do |c1, c2|
+        next 0 unless c1 && c2 # Add nil guard for individual components
+
+        (c1 + ((c2 - c1) * progress)).round
       end
     end
 
@@ -991,6 +1263,40 @@ module Sai
       end
     end
 
+    # Prepare foreground and background color sequences for text
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api private
+    #
+    # @param text_length [Integer] length of text to color
+    #
+    # @return [Hash] adjusted color sequences
+    # @rbs (Integer text_length) -> Hash[Symbol, Array[Array[Integer]]]
+    def prepare_color_sequences(text_length)
+      sequences = {}
+      sequences[:foreground] = prepare_sequence(@foreground_sequence, text_length) if @foreground_sequence
+      sequences[:background] = prepare_sequence(@background_sequence, text_length) if @background_sequence
+      sequences
+    end
+
+    # Prepare a single color sequence
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api private
+    #
+    # @param sequence [Array<Array<Integer>>, nil] color sequence to prepare
+    # @param text_length [Integer] length of text to color
+    #
+    # @return [Array<Array<Integer>>, nil] adjusted color sequence
+    # @rbs (Array[Array[Integer]]? sequence, Integer text_length) -> Array[Array[Integer]]?
+    def prepare_sequence(sequence, text_length)
+      sequence && adjust_colors_to_text_length(sequence, text_length)
+    end
+
     # Check if text should be decorated
     #
     # @author {https://aaronmallen.me Aaron Allen}
@@ -1002,9 +1308,62 @@ module Sai
     # @rbs () -> bool
     def should_decorate?
       return false if @mode == Terminal::ColorMode::NO_COLOR
-      return false if @foreground.nil? && @background.nil? && @styles.empty?
+      return false if @foreground.nil? && @background.nil? && @styles.empty? &&
+                      @foreground_sequence.nil? && @background_sequence.nil?
 
       true
+    end
+
+    # Shrink a color sequence to fit desired length
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api private
+    #
+    # @param colors [Array<Array<Integer>>] original color sequence
+    # @param target_length [Integer] desired number of colors
+    #
+    # @return [Array<Array<Integer>>] shrunk color sequence
+    # @rbs (Array[Array[Integer]] colors, Integer target_length) -> Array[Array[Integer]]
+    def shrink_colors(colors, target_length)
+      step_size = (target_length - 1).to_f / (colors.length - 1)
+      indices = (0...colors.length).select { |i| (i * step_size).round < target_length }
+      indices.map { |i| colors[i] }
+    end
+
+    # Stretch a color sequence to fit desired length
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api private
+    #
+    # @param colors [Array<Array<Integer>>] original color sequence
+    # @param target_length [Integer] desired number of colors
+    #
+    # @return [Array<Array<Integer>>] stretched color sequence
+    # @rbs (Array[Array[Integer]] colors, Integer target_length) -> Array[Array[Integer]]
+    def stretch_colors(colors, target_length)
+      step_size = (colors.length - 1).to_f / (target_length - 1)
+
+      (0...target_length).map do |i|
+        indices = calculate_interpolation_indices(i, step_size, colors.length)
+        interpolate_sequence_colors(colors, indices)
+      end
+    end
+
+    # Get style sequences
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api private
+    #
+    # @return [Array<String>] ANSI sequences for styles
+    # @rbs () -> Array[String]
+    def style_sequences
+      @styles.map { |style| "\e[#{ANSI::STYLES[style]}m" }
     end
   end
 end

--- a/sig/sai/conversion/rgb.rbs
+++ b/sig/sai/conversion/rgb.rbs
@@ -54,6 +54,26 @@ module Sai
       # @rbs ((Array[Integer] | String | Symbol) color, Float amount) -> Array[Integer]
       def self.darken: (Array[Integer] | String | Symbol color, Float amount) -> Array[Integer]
 
+      # Generate a gradient between two colors with a specified number of steps
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @param start_color [Array<Integer>, String, Symbol] the starting color
+      # @param end_color [Array<Integer>, String, Symbol] the ending color
+      # @param steps [Integer] the number of colors to generate (minimum 2)
+      #
+      # @raise [ArgumentError] if steps is less than 2
+      # @return [Array<Array<Integer>>] the gradient colors as RGB values
+      # @rbs (
+      #   (Array[Integer] | String | Symbol) start_color,
+      #   (Array[Integer] | String | Symbol) end_color,
+      #   Integer steps
+      #   ) -> Array[Array[Integer]]
+      def self.gradient: (Array[Integer] | String | Symbol start_color, Array[Integer] | String | Symbol end_color, Integer steps) -> Array[Array[Integer]]
+
       # Determine if a color is grayscale
       #
       # @author {https://aaronmallen.me Aaron Allen}
@@ -69,6 +89,26 @@ module Sai
       # @rbs (Float red, Float green, Float blue) -> bool
       def self.grayscale?: (Float red, Float green, Float blue) -> bool
 
+      # Interpolate between two colors to create a gradient step
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @param start_color [Array<Integer>, String, Symbol] the starting color
+      # @param end_color [Array<Integer>, String, Symbol] the ending color
+      # @param step [Float] the interpolation step (0.0-1.0)
+      #
+      # @raise [ArgumentError] if step is not between 0.0 and 1.0
+      # @return [Array<Integer>] the interpolated RGB values
+      # @rbs (
+      #   (Array[Integer] | String | Symbol) start_color,
+      #   (Array[Integer] | String | Symbol) end_color,
+      #   Float step
+      #   ) -> Array[Integer]
+      def self.interpolate_color: (Array[Integer] | String | Symbol start_color, Array[Integer] | String | Symbol end_color, Float step) -> Array[Integer]
+
       # Lighten an RGB color by a percentage
       #
       # @author {https://aaronmallen.me Aaron Allen}
@@ -83,6 +123,20 @@ module Sai
       # @return [Array<Integer>] the lightened RGB values
       # @rbs ((Array[Integer] | String | Symbol) color, Float amount) -> Array[Integer]
       def self.lighten: (Array[Integer] | String | Symbol color, Float amount) -> Array[Integer]
+
+      # Generate a rainbow gradient with a specified number of steps
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @param steps [Integer] the number of colors to generate (minimum 2)
+      #
+      # @raise [ArgumentError] if steps is less than 2
+      # @return [Array<Array<Integer>>] the rainbow gradient colors as RGB values
+      # @rbs (Integer steps) -> Array[Array[Integer]]
+      def self.rainbow_gradient: (Integer steps) -> Array[Array[Integer]]
 
       # Convert a color value to RGB components
       #
@@ -124,6 +178,21 @@ module Sai
       # @rbs (Array[Integer] rgb) -> Integer
       def self.to_grayscale_index: (Array[Integer] rgb) -> Integer
 
+      # Calculate the intermediate HSV components
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @param value [Float] the value component
+      # @param saturation [Float] the saturation component
+      # @param hue_remainder [Float] the remainder of hue / 60
+      #
+      # @return [Array<Float>] the primary, secondary, and tertiary components
+      # @rbs (Float value, Float saturation, Float hue_remainder) -> [Float, Float, Float]
+      private def self.calculate_hsv_components: (Float value, Float saturation, Float hue_remainder) -> [ Float, Float, Float ]
+
       # Check if RGB values represent cyan
       #
       # @author {https://aaronmallen.me Aaron Allen}
@@ -151,6 +220,21 @@ module Sai
       # @return [Array<Integer>] the RGB components
       # @rbs (String hex) -> Array[Integer]
       private def self.hex_to_rgb: (String hex) -> Array[Integer]
+
+      # Convert HSV values to RGB
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @param hue [Float] the hue component (0-360)
+      # @param saturation [Float] the saturation component (0-1)
+      # @param value [Float] the value component (0-1)
+      #
+      # @return [Array<Integer>] the RGB values
+      # @rbs (Float hue, Float saturation, Float value) -> Array[Integer]
+      private def self.hsv_to_rgb: (Float hue, Float saturation, Float value) -> Array[Integer]
 
       # Check if RGB values represent magenta
       #
@@ -180,6 +264,19 @@ module Sai
       # @return [Array<Integer>] the RGB components
       # @rbs (String color_name) -> Array[Integer]
       private def self.named_to_rgb: (String color_name) -> Array[Integer]
+
+      # Convert RGB values from 0-1 range to 0-255 range
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @param rgb [Array<Float>] RGB values in 0-1 range
+      #
+      # @return [Array<Integer>] RGB values in 0-255 range
+      # @rbs (Array[Float] rgb) -> Array[Integer]
+      private def self.normalize_rgb: (Array[Float] rgb) -> Array[Integer]
 
       # Determine if RGB values represent a primary color
       #
@@ -240,6 +337,23 @@ module Sai
       # @return [Symbol] the secondary color name
       # @rbs (Float red, Float green, Float blue) -> Symbol
       private def self.secondary_color: (Float red, Float green, Float blue) -> Symbol
+
+      # Select RGB values based on the hue sector
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @param sector [Integer] the hue sector (0-5)
+      # @param value [Float] the value component
+      # @param primary [Float] primary component from HSV calculation
+      # @param secondary [Float] secondary component from HSV calculation
+      # @param tertiary [Float] tertiary component from HSV calculation
+      #
+      # @return [Array<Float>] the RGB values before normalization
+      # @rbs (Integer sector, Float value, Float primary, Float secondary, Float tertiary) -> Array[Float]
+      private def self.select_rgb_values: (Integer sector, Float value, Float primary, Float secondary, Float tertiary) -> Array[Float]
 
       # Validate RGB values
       #

--- a/sig/sai/decorator.rbs
+++ b/sig/sai/decorator.rbs
@@ -179,6 +179,30 @@ module Sai
 
     alias encode decorate
 
+    # Build a foreground gradient between two colors for text decoration
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api public
+    #
+    # @example Create a foreground gradient from red to blue
+    #   decorator.gradient(:red, :blue, 10).decorate('Hello, World!')
+    #   #=> "\e[38;2;255;0;0mH\e[0m\e[38;2;204;0;51me\e[0m..."
+    #
+    # @param start_color [Array<Integer>, String, Symbol] the starting color
+    # @param end_color [Array<Integer>, String, Symbol] the ending color
+    # @param steps [Integer] the number of gradient steps (minimum 2)
+    #
+    # @raise [ArgumentError] if steps is less than 2
+    # @return [Decorator] a new instance of Decorator with foreground gradient colors
+    # @rbs (
+    #   Array[Integer] | String | Symbol start_color,
+    #   Array[Integer] | String | Symbol end_color,
+    #   Integer steps
+    #   ) -> Decorator
+    def gradient: (Array[Integer] | String | Symbol start_color, Array[Integer] | String | Symbol end_color, Integer steps) -> Decorator
+
     # Apply a hexadecimal color to the foreground
     #
     # @author {https://aaronmallen.me Aaron Allen}
@@ -237,6 +261,30 @@ module Sai
 
     alias lighten_foreground lighten_text
 
+    # Build a background gradient between two colors for text decoration
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api public
+    #
+    # @example Create a background gradient from red to blue
+    #   decorator.on_gradient(:red, :blue, 10).decorate('Hello, World!')
+    #   #=> "\e[48;2;255;0;0mH\e[0m\e[48;2;204;0;51me\e[0m..."
+    #
+    # @param start_color [Array<Integer>, String, Symbol] the starting color
+    # @param end_color [Array<Integer>, String, Symbol] the ending color
+    # @param steps [Integer] the number of gradient steps (minimum 2)
+    #
+    # @raise [ArgumentError] if steps is less than 2
+    # @return [Decorator] a new instance of Decorator with background gradient colors
+    # @rbs (
+    #   Array[Integer] | String | Symbol start_color,
+    #   Array[Integer] | String | Symbol end_color,
+    #   Integer steps
+    #   ) -> Decorator
+    def on_gradient: (Array[Integer] | String | Symbol start_color, Array[Integer] | String | Symbol end_color, Integer steps) -> Decorator
+
     # Apply a hexadecimal color to the background
     #
     # @author {https://aaronmallen.me Aaron Allen}
@@ -253,6 +301,24 @@ module Sai
     # @return [Decorator] a new instance of Decorator with the hex color applied
     # @rbs (String code) -> Decorator
     def on_hex: (String code) -> Decorator
+
+    # Build a background rainbow gradient for text decoration
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api public
+    #
+    # @example Create a rainbow background gradient
+    #   decorator.on_rainbow(6).decorate('Hello, World!')
+    #   #=> "\e[48;2;255;0;0mH\e[0m\e[48;2;255;255;0me\e[0m..."
+    #
+    # @param steps [Integer] the number of colors to generate (minimum 2)
+    #
+    # @raise [ArgumentError] if steps is less than 2
+    # @return [Decorator] a new instance of Decorator with background rainbow colors
+    # @rbs (Integer steps) -> Decorator
+    def on_rainbow: (Integer steps) -> Decorator
 
     # Apply an RGB color to the background
     #
@@ -272,6 +338,24 @@ module Sai
     # @return [Decorator] a new instance of Decorator with the RGB color applied
     # @rbs (Integer red, Integer green, Integer blue) -> Decorator
     def on_rgb: (Integer red, Integer green, Integer blue) -> Decorator
+
+    # Build a foreground rainbow gradient for text decoration
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api public
+    #
+    # @example Create a rainbow text gradient
+    #   decorator.rainbow(6).decorate('Hello, World!')
+    #   #=> "\e[38;2;255;0;0mH\e[0m\e[38;2;255;255;0me\e[0m..."
+    #
+    # @param steps [Integer] the number of colors to generate (minimum 2)
+    #
+    # @raise [ArgumentError] if steps is less than 2
+    # @return [Decorator] a new instance of Decorator with foreground rainbow colors
+    # @rbs (Integer steps) -> Decorator
+    def rainbow: (Integer steps) -> Decorator
 
     # Apply an RGB color to the foreground
     #
@@ -310,6 +394,20 @@ module Sai
 
     private
 
+    # Adjust number of colors to match text length
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api private
+    #
+    # @param colors [Array<Array<Integer>>] original color sequence
+    # @param text_length [Integer] desired number of colors
+    #
+    # @return [Array<Array<Integer>>] adjusted color sequence
+    # @rbs (Array[Array[Integer]] colors, Integer text_length) -> Array[Array[Integer]]
+    def adjust_colors_to_text_length: (Array[Array[Integer]] colors, Integer text_length) -> Array[Array[Integer]]
+
     # Apply a named color to the specified style type
     #
     # @author {https://aaronmallen.me Aaron Allen}
@@ -324,6 +422,19 @@ module Sai
     # @rbs (Conversion::ColorSequence::style_type style_type, Symbol color) -> Decorator
     def apply_named_color: (Conversion::ColorSequence::style_type style_type, Symbol color) -> Decorator
 
+    # Apply color sequence gradients to text
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api private
+    #
+    # @param text [String] the text to apply the gradient to
+    #
+    # @return [ANSI::SequencedString] the text with gradient applied
+    # @rbs (String text) -> ANSI::SequencedString
+    def apply_sequence_gradient: (String text) -> ANSI::SequencedString
+
     # Apply a style to the text
     #
     # @author {https://aaronmallen.me Aaron Allen}
@@ -336,6 +447,49 @@ module Sai
     # @return [Decorator] a new instance of Decorator with the style applied
     # @rbs (String | Symbol style) -> self
     def apply_style: (String | Symbol style) -> self
+
+    # Build color sequences for a single character
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api private
+    #
+    # @param colors [Hash] color sequences for foreground and background
+    # @param index [Integer] character position
+    #
+    # @return [Array<String>] ANSI sequences for the character
+    # @rbs (Hash[Symbol, Array[Array[Integer]]] colors, Integer index) -> Array[String]
+    def build_color_sequences: (Hash[Symbol, Array[Array[Integer]]] colors, Integer index) -> Array[String]
+
+    # Build gradient text from characters and color sequences
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api private
+    #
+    # @param chars [Array<String>] text characters
+    # @param colors [Hash] color sequences for foreground and background
+    #
+    # @return [Array<String>] colored characters
+    # @rbs (Array[String] chars, Hash[Symbol, Array[Array[Integer]]] colors) -> Array[String]
+    def build_gradient_text: (Array[String] chars, Hash[Symbol, Array[Array[Integer]]] colors) -> Array[String]
+
+    # Calculate indices and progress for color interpolation
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api private
+    #
+    # @param position [Integer] current position in sequence
+    # @param step_size [Float] size of each step
+    # @param max_index [Integer] maximum index allowed
+    #
+    # @return [Hash] interpolation indices and progress
+    # @rbs (Integer position, Float step_size, Integer max_index) -> Hash[Symbol, Integer | Float]
+    def calculate_interpolation_indices: (Integer position, Float step_size, Integer max_index) -> Hash[Symbol, Integer | Float]
 
     # Darken the foreground or background color by a specified amount
     #
@@ -351,6 +505,48 @@ module Sai
     # @rbs (Float amount, Symbol component) -> Decorator
     def darken: (Float amount, Symbol component) -> Decorator
 
+    # Get background sequence for a character
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api private
+    #
+    # @param colors [Array<Array<Integer>>, nil] background color sequence
+    # @param index [Integer] character position
+    #
+    # @return [String, nil] ANSI sequence for background
+    # @rbs (Array[Array[Integer]]? colors, Integer index) -> String?
+    def get_background_sequence: (Array[Array[Integer]]? colors, Integer index) -> String?
+
+    # Get foreground sequence for a character
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api private
+    #
+    # @param colors [Array<Array<Integer>>, nil] foreground color sequence
+    # @param index [Integer] character position
+    #
+    # @return [String, nil] ANSI sequence for foreground
+    # @rbs (Array[Array[Integer]]? colors, Integer index) -> String?
+    def get_foreground_sequence: (Array[Array[Integer]]? colors, Integer index) -> String?
+
+    # Interpolate between two colors in a sequence
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api private
+    #
+    # @param colors [Array<Array<Integer>>] color sequence
+    # @param indices [Hash] interpolation indices and progress
+    #
+    # @return [Array<Integer>] interpolated color
+    # @rbs (Array[Array[Integer]] colors, Hash[Symbol, Integer | Float]) -> Array[Integer]
+    def interpolate_sequence_colors: (Array[Array[Integer]] colors, Hash[Symbol, Integer | Float]) -> Array[Integer]
+
     # Lighten the foreground or background color by a specified amount
     #
     # @author {https://aaronmallen.me Aaron Allen}
@@ -365,6 +561,33 @@ module Sai
     # @rbs (Float amount, Symbol component) -> Decorator
     def lighten: (Float amount, Symbol component) -> Decorator
 
+    # Prepare foreground and background color sequences for text
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api private
+    #
+    # @param text_length [Integer] length of text to color
+    #
+    # @return [Hash] adjusted color sequences
+    # @rbs (Integer text_length) -> Hash[Symbol, Array[Array[Integer]]]
+    def prepare_color_sequences: (Integer text_length) -> Hash[Symbol, Array[Array[Integer]]]
+
+    # Prepare a single color sequence
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api private
+    #
+    # @param sequence [Array<Array<Integer>>, nil] color sequence to prepare
+    # @param text_length [Integer] length of text to color
+    #
+    # @return [Array<Array<Integer>>, nil] adjusted color sequence
+    # @rbs (Array[Array[Integer]]? sequence, Integer text_length) -> Array[Array[Integer]]?
+    def prepare_sequence: (Array[Array[Integer]]? sequence, Integer text_length) -> Array[Array[Integer]]?
+
     # Check if text should be decorated
     #
     # @author {https://aaronmallen.me Aaron Allen}
@@ -375,5 +598,44 @@ module Sai
     # @return [Boolean] `true` if text should be decorated, `false` otherwise
     # @rbs () -> bool
     def should_decorate?: () -> bool
+
+    # Shrink a color sequence to fit desired length
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api private
+    #
+    # @param colors [Array<Array<Integer>>] original color sequence
+    # @param target_length [Integer] desired number of colors
+    #
+    # @return [Array<Array<Integer>>] shrunk color sequence
+    # @rbs (Array[Array[Integer]] colors, Integer target_length) -> Array[Array[Integer]]
+    def shrink_colors: (Array[Array[Integer]] colors, Integer target_length) -> Array[Array[Integer]]
+
+    # Stretch a color sequence to fit desired length
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api private
+    #
+    # @param colors [Array<Array<Integer>>] original color sequence
+    # @param target_length [Integer] desired number of colors
+    #
+    # @return [Array<Array<Integer>>] stretched color sequence
+    # @rbs (Array[Array[Integer]] colors, Integer target_length) -> Array[Array[Integer]]
+    def stretch_colors: (Array[Array[Integer]] colors, Integer target_length) -> Array[Array[Integer]]
+
+    # Get style sequences
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api private
+    #
+    # @return [Array<String>] ANSI sequences for styles
+    # @rbs () -> Array[String]
+    def style_sequences: () -> Array[String]
   end
 end

--- a/spec/sai/conversion/rgb_spec.rb
+++ b/spec/sai/conversion/rgb_spec.rb
@@ -83,6 +83,82 @@ RSpec.describe Sai::Conversion::RGB do
     end
   end
 
+  describe '.gradient' do
+    subject(:gradient) { described_class.gradient(start_color, end_color, steps) }
+
+    context 'when given valid RGB arrays' do
+      let(:start_color) { [255, 0, 0] }
+      let(:end_color) { [0, 0, 255] }
+      let(:steps) { 3 }
+
+      it 'is expected to return an array of RGB colors' do
+        expect(gradient).to eq([
+                                 [255, 0, 0],
+                                 [128, 0, 128],
+                                 [0, 0, 255]
+                               ])
+      end
+    end
+
+    context 'when given valid hex colors' do
+      let(:start_color) { '#FF0000' }
+      let(:end_color) { '#0000FF' }
+      let(:steps) { 3 }
+
+      it 'is expected to return an array of RGB colors' do
+        expect(gradient).to eq([
+                                 [255, 0, 0],
+                                 [128, 0, 128],
+                                 [0, 0, 255]
+                               ])
+      end
+    end
+
+    context 'when given valid named colors' do
+      let(:start_color) { :red }
+      let(:end_color) { :blue }
+      let(:steps) { 3 }
+
+      it 'is expected to return an array of RGB colors' do
+        start_rgb = Sai::ANSI::COLOR_NAMES[:red]
+        end_rgb = Sai::ANSI::COLOR_NAMES[:blue]
+        expect(gradient).to eq([
+                                 start_rgb,
+                                 [103, 0, 119],
+                                 end_rgb
+                               ])
+      end
+    end
+
+    context 'when mixing color formats' do
+      let(:start_color) { '#FF0000' }
+      let(:end_color) { :blue }
+      let(:steps) { 3 }
+
+      it 'is expected to return an array of RGB colors' do
+        end_rgb = Sai::ANSI::COLOR_NAMES[:blue]
+        expect(gradient).to eq([
+                                 [255, 0, 0],
+                                 [128, 0, (end_rgb[2] / 2.0).round],
+                                 end_rgb
+                               ])
+      end
+    end
+
+    context 'when given invalid steps' do
+      let(:start_color) { [255, 0, 0] }
+      let(:end_color) { [0, 0, 255] }
+
+      context 'when steps is less than 2' do
+        let(:steps) { 1 }
+
+        it 'is expected to raise ArgumentError' do
+          expect { gradient }.to raise_error(ArgumentError, /Steps must be at least 2/)
+        end
+      end
+    end
+  end
+
   describe '.darken' do
     subject(:darken) { described_class.darken(color, amount) }
 
@@ -139,6 +215,60 @@ RSpec.describe Sai::Conversion::RGB do
 
         it 'is expected to raise ArgumentError' do
           expect { darken }.to raise_error(ArgumentError, /Invalid amount/)
+        end
+      end
+    end
+  end
+
+  describe '.interpolate_color' do
+    subject(:interpolate_color) { described_class.interpolate_color(start_color, end_color, step) }
+
+    context 'when given valid RGB arrays' do
+      let(:start_color) { [255, 0, 0] }
+      let(:end_color) { [0, 0, 255] }
+
+      context 'when step is 0.0' do
+        let(:step) { 0.0 }
+
+        it 'is expected to return the start color' do
+          expect(interpolate_color).to eq(start_color)
+        end
+      end
+
+      context 'when step is 1.0' do
+        let(:step) { 1.0 }
+
+        it 'is expected to return the end color' do
+          expect(interpolate_color).to eq(end_color)
+        end
+      end
+
+      context 'when step is 0.5' do
+        let(:step) { 0.5 }
+
+        it 'is expected to return the midpoint color' do
+          expect(interpolate_color).to eq([128, 0, 128])
+        end
+      end
+    end
+
+    context 'when given invalid step' do
+      let(:start_color) { [255, 0, 0] }
+      let(:end_color) { [0, 0, 255] }
+
+      context 'when step is negative' do
+        let(:step) { -0.1 }
+
+        it 'is expected to raise ArgumentError' do
+          expect { interpolate_color }.to raise_error(ArgumentError, /Invalid step/)
+        end
+      end
+
+      context 'when step is greater than 1.0' do
+        let(:step) { 1.1 }
+
+        it 'is expected to raise ArgumentError' do
+          expect { interpolate_color }.to raise_error(ArgumentError, /Invalid step/)
         end
       end
     end
@@ -201,6 +331,50 @@ RSpec.describe Sai::Conversion::RGB do
         it 'is expected to raise ArgumentError' do
           expect { lighten }.to raise_error(ArgumentError, /Invalid amount/)
         end
+      end
+    end
+  end
+
+  describe '.rainbow_gradient' do
+    subject(:rainbow_gradient) { described_class.rainbow_gradient(steps) }
+
+    context 'when given valid steps' do
+      let(:steps) { 6 }
+
+      it 'is expected to return an array of RGB colors' do
+        expect(rainbow_gradient).to eq([
+                                         [255, 0, 0],     # Red (0°)
+                                         [255, 255, 0],   # Yellow (60°)
+                                         [0, 255, 0],     # Green (120°)
+                                         [0, 255, 255],   # Cyan (180°)
+                                         [0, 0, 255],     # Blue (240°)
+                                         [255, 0, 255]    # Magenta (300°)
+                                       ])
+      end
+
+      it 'is expected to return the specified number of colors' do
+        expect(rainbow_gradient.size).to eq(steps)
+      end
+    end
+
+    context 'when given invalid steps' do
+      context 'when steps is less than 2' do
+        let(:steps) { 1 }
+
+        it 'is expected to raise ArgumentError' do
+          expect { rainbow_gradient }.to raise_error(ArgumentError, /Steps must be at least 2/)
+        end
+      end
+    end
+
+    context 'when checking color values' do
+      let(:steps) { 12 }
+
+      it 'is expected to return valid RGB values' do
+        expect(rainbow_gradient).to all(satisfy { |color|
+          color.size == 3 &&
+            color.all? { |c| c.is_a?(Integer) && c.between?(0, 255) }
+        })
       end
     end
   end

--- a/spec/sai/decorator_spec.rb
+++ b/spec/sai/decorator_spec.rb
@@ -157,6 +157,44 @@ RSpec.describe Sai::Decorator do
     end
   end
 
+  describe '#gradient' do
+    subject(:gradient_decorator) { decorator.gradient(start_color, end_color, steps) }
+
+    let(:decorator) { described_class.new(mode: Sai::Terminal::ColorMode::TRUE_COLOR) }
+    let(:start_color) { :red }
+    let(:end_color) { :blue }
+    let(:steps) { 3 }
+    let(:text) { 'RGB' }
+
+    it { is_expected.to be_an_instance_of(described_class) }
+
+    it 'is expected to return a new instance' do
+      expect(gradient_decorator).not_to eq(decorator)
+    end
+
+    it 'is expected to set the foreground sequence on the new instance' do
+      expect(gradient_decorator.instance_variable_get(:@foreground_sequence)).to be_an(Array)
+    end
+
+    it 'is expected to create a gradient with the specified number of colors' do
+      sequence = gradient_decorator.instance_variable_get(:@foreground_sequence)
+      expect(sequence.length).to eq(steps)
+    end
+
+    it 'is expected to apply the gradient to text' do
+      result = gradient_decorator.decorate(text).to_s
+      expect(result).to match(/\e\[38;2;\d+;\d+;\d+mR\e\[0m\e\[38;2;\d+;\d+;\d+mG\e\[0m\e\[38;2;\d+;\d+;\d+mB\e\[0m/)
+    end
+
+    context 'when given invalid steps' do
+      let(:steps) { 1 }
+
+      it 'is expected to raise ArgumentError' do
+        expect { gradient_decorator }.to raise_error(ArgumentError, /Steps must be at least 2/)
+      end
+    end
+  end
+
   describe '#hex' do
     subject(:hex_decorator) { decorator.hex(code) }
 
@@ -278,6 +316,44 @@ RSpec.describe Sai::Decorator do
     end
   end
 
+  describe '#on_gradient' do
+    subject(:on_gradient_decorator) { decorator.on_gradient(start_color, end_color, steps) }
+
+    let(:decorator) { described_class.new(mode: Sai::Terminal::ColorMode::TRUE_COLOR) }
+    let(:start_color) { :red }
+    let(:end_color) { :blue }
+    let(:steps) { 3 }
+    let(:text) { 'RGB' }
+
+    it { is_expected.to be_an_instance_of(described_class) }
+
+    it 'is expected to return a new instance' do
+      expect(on_gradient_decorator).not_to eq(decorator)
+    end
+
+    it 'is expected to set the background sequence on the new instance' do
+      expect(on_gradient_decorator.instance_variable_get(:@background_sequence)).to be_an(Array)
+    end
+
+    it 'is expected to create a gradient with the specified number of colors' do
+      sequence = on_gradient_decorator.instance_variable_get(:@background_sequence)
+      expect(sequence.length).to eq(steps)
+    end
+
+    it 'is expected to apply the gradient to text' do
+      result = on_gradient_decorator.decorate(text).to_s
+      expect(result).to match(/\e\[48;2;\d+;\d+;\d+mR\e\[0m\e\[48;2;\d+;\d+;\d+mG\e\[0m\e\[48;2;\d+;\d+;\d+mB\e\[0m/)
+    end
+
+    context 'when given invalid steps' do
+      let(:steps) { 1 }
+
+      it 'is expected to raise ArgumentError' do
+        expect { on_gradient_decorator }.to raise_error(ArgumentError, /Steps must be at least 2/)
+      end
+    end
+  end
+
   describe '#on_hex' do
     subject(:on_hex_decorator) { decorator.on_hex(code) }
 
@@ -349,6 +425,42 @@ RSpec.describe Sai::Decorator do
     end
   end
 
+  describe '#on_rainbow' do
+    subject(:on_rainbow_decorator) { decorator.on_rainbow(steps) }
+
+    let(:decorator) { described_class.new(mode: Sai::Terminal::ColorMode::TRUE_COLOR) }
+    let(:steps) { 6 }
+    let(:text) { 'RAINBOW' }
+
+    it { is_expected.to be_an_instance_of(described_class) }
+
+    it 'is expected to return a new instance' do
+      expect(on_rainbow_decorator).not_to eq(decorator)
+    end
+
+    it 'is expected to set the background sequence on the new instance' do
+      expect(on_rainbow_decorator.instance_variable_get(:@background_sequence)).to be_an(Array)
+    end
+
+    it 'is expected to create a sequence with the specified number of colors' do
+      sequence = on_rainbow_decorator.instance_variable_get(:@background_sequence)
+      expect(sequence.length).to eq(steps)
+    end
+
+    it 'is expected to apply rainbow colors to text' do
+      result = on_rainbow_decorator.decorate(text).to_s
+      expect(result).to match(/(\e\[48;2;\d+;\d+;\d+m[A-Z]\e\[0m){6}/)
+    end
+
+    context 'when given invalid steps' do
+      let(:steps) { 1 }
+
+      it 'is expected to raise ArgumentError' do
+        expect { on_rainbow_decorator }.to raise_error(ArgumentError, /Steps must be at least 2/)
+      end
+    end
+  end
+
   describe '#on_rgb' do
     subject(:on_rgb_decorator) { decorator.on_rgb(red, green, blue) }
 
@@ -381,6 +493,42 @@ RSpec.describe Sai::Decorator do
 
       it 'is expected to raise an ArgumentError' do
         expect { on_rgb_decorator }.to raise_error(ArgumentError, 'Invalid RGB value: 300, 65, 51')
+      end
+    end
+  end
+
+  describe '#rainbow' do
+    subject(:rainbow_decorator) { decorator.rainbow(steps) }
+
+    let(:decorator) { described_class.new(mode: Sai::Terminal::ColorMode::TRUE_COLOR) }
+    let(:steps) { 6 }
+    let(:text) { 'RAINBOW' }
+
+    it { is_expected.to be_an_instance_of(described_class) }
+
+    it 'is expected to return a new instance' do
+      expect(rainbow_decorator).not_to eq(decorator)
+    end
+
+    it 'is expected to set the foreground sequence on the new instance' do
+      expect(rainbow_decorator.instance_variable_get(:@foreground_sequence)).to be_an(Array)
+    end
+
+    it 'is expected to create a sequence with the specified number of colors' do
+      sequence = rainbow_decorator.instance_variable_get(:@foreground_sequence)
+      expect(sequence.length).to eq(steps)
+    end
+
+    it 'is expected to apply rainbow colors to text' do
+      result = rainbow_decorator.decorate(text).to_s
+      expect(result).to match(/(\e\[38;2;\d+;\d+;\d+m[A-Z]\e\[0m){6}/)
+    end
+
+    context 'when given invalid steps' do
+      let(:steps) { 1 }
+
+      it 'is expected to raise ArgumentError' do
+        expect { rainbow_decorator }.to raise_error(ArgumentError, /Steps must be at least 2/)
       end
     end
   end


### PR DESCRIPTION
This adds support for dynamic color transitions with gradient and rainbow effects for both text and backgrounds. 

## Key Features

* Generate gradient colors between any two colors (hex, RGB, or named colors)
* Create rainbow gradients with customizable number of color steps
* Support for both foreground (text) and background color transitions
* Automatic scaling of gradients to match text length
* Preservation of spaces without color effects

## Example Usage

```ruby
# Text gradients
Sai.gradient('#000000', '#FFFFFF', 5).decorate('Fade to white')
Sai.gradient(:red, :blue, 10).decorate('Red to blue transition')
Sai.rainbow(6).decorate('🌈 Rainbow text!')

# Background gradients 
Sai.on_gradient('#FF0000', '#0000FF', 8).decorate('Red-blue bg fade')
Sai.on_gradient(:yellow, :green, 5).decorate('Nature vibes')
Sai.on_rainbow(6).decorate('Rainbow backdrop')

# Mix and match
Sai.rainbow(5).on_gradient(:black, :white, 5).decorate('Double gradient!')
```

The gradients automatically adjust to fit text length while preserving readability for spaces. You can specify any number of gradient steps (minimum 2) to control the smoothness of the transitions.

## Technical Details
* Added RGB color interpolation support
* Added HSV to RGB conversion for rainbow effects
* Added sequence stretching/shrinking to match text length
* Updated color sequence application to handle per-character colors
* Added tests for all new functionality
* Updated documentation with examples and best practices