### PR TITLE
Add support for registering custom named colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog], and this project adheres to [Break Ve
 
 ## [Unreleased]
 
+### Added
+
+* [#15](https://github.com/aaronmallen/sai/pull/15) - Add support for registering custom named colors by
+  [@aaronmallen](https://github.com/aaronmallen)
+
 ## [0.3.1] - 2025-01-22
 
 ### Added 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -107,6 +107,20 @@ For a complete list of available colors, see:
 * [Online Color Reference](https://github.com/aaronmallen/sai/blob/main/docs/AVAILABLE_NAMED_COLORS.md)
 * `Sai::NamedColors.names` in your code
 
+#### Registering Custom Named Colors
+
+Sai allows you to register custom named colors for easy reuse with `Sai.register`:
+
+```ruby
+# Register custom colors
+Sai.register(:my_color, '#CF4C5F')
+
+# or alternatively 
+Sai.register(:my_color, [207, 76, 95])
+
+Sai.my_color.decorate('Hello, world!')
+```
+
 ### Color Manipulation
 
 Adjust the brightness of colors:

--- a/lib/sai.rb
+++ b/lib/sai.rb
@@ -833,6 +833,28 @@ module Sai
       ModeSelector
     end
 
+    # Register a custom name and color
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api public
+    #
+    # @example Register a color
+    #   Sai.register(:my_color, '#CF4C5F')
+    #   Sai.register(:my_color, [207, 76, 95])
+    #
+    #   Sai.my_color.decorate('Hello, world!').to_s #=> "\e[38;2;207;76;95mHello, world!\e[0m"
+    #
+    # @param name [String, Symbol] the name of the color to register
+    # @param rgb_or_hex [Array<Integer>, String] the RGB values or hex code to register
+    #
+    # @return [void]
+    # @rbs (String | Symbol name, Array[Integer] | String rgb_or_hex) -> void
+    def register(name, rgb_or_hex)
+      NamedColors.register(name, rgb_or_hex)
+    end
+
     # Sequence a string with ANSI escape codes
     #
     # @author {https://aaronmallen.me Aaron Allen}

--- a/lib/sai/decorator/delegation.rb
+++ b/lib/sai/decorator/delegation.rb
@@ -52,6 +52,7 @@ module Sai
           methods = collect_delegatable_methods.reject { |m| ignored_methods.include?(m) }
 
           methods.each do |method|
+            klass.undef_method(method) if klass.method_defined?(method)
             klass.define_method(method) do |*args, **kwargs|
               Decorator.new(mode: Sai.mode.auto).public_send(method, *args, **kwargs)
             end

--- a/lib/sai/decorator/named_colors.rb
+++ b/lib/sai/decorator/named_colors.rb
@@ -749,14 +749,26 @@ module Sai
       #   def yellow_green: () -> Decorator
       #   def yellow_system: () -> Decorator
 
-      Sai::NamedColors.names.each do |color|
-        define_method(color) do
-          apply_named_color(:foreground, color)
-        end
-        define_method(:"on_#{color}") do
-          apply_named_color(:background, color)
+      # Install a color method on the {Decorator} class
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @param color_name [Symbol] the name of the color to install
+      #
+      # @return [void]
+      # @rbs (Symbol color_name) -> void
+      def self.install(color_name)
+        { color_name => :foreground, :"on_#{color_name}" => :background }.each do |method_name, style_type|
+          # @type var style_type: Sai::Conversion::ColorSequence::style_type
+          Sai::Decorator.undef_method(method_name) if Sai::Decorator.method_defined?(method_name)
+          Sai::Decorator.define_method(method_name) { apply_named_color(style_type, color_name) }
         end
       end
+
+      Sai::NamedColors.names.each { |color| Sai::Decorator::NamedColors.install(color) }
 
       private
 

--- a/lib/sai/named_colors.rb
+++ b/lib/sai/named_colors.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'sai/conversion/rgb'
+
 module Sai
   # A collection of named colors and their RGB values
   #
@@ -406,32 +408,82 @@ module Sai
     }.freeze #: Hash[Symbol, Array[Integer]]
     # rubocop:enable Naming/VariableNumber
 
-    # Look up an RGB value by color name
-    #
-    # @author {https://aaronmallen.me Aaron Allen}
-    # @since 0.3.1
-    #
-    # @api private
-    #
-    # @param name [String, Symbol] the color name
-    #
-    # @return [Array<Integer>] the RGB value
-    # @rbs (String | Symbol name) -> Array[Integer]?
-    def self.[](name)
-      key = name.to_sym
-      ANSI.fetch(key, XTERM.fetch(key, CSS.fetch(key, nil)))
-    end
+    class << self
+      # Look up an RGB value by color name
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since 0.3.1
+      #
+      # @api private
+      #
+      # @param name [String, Symbol] the color name
+      #
+      # @return [Array<Integer>] the RGB value
+      # @rbs (String | Symbol name) -> Array[Integer]?
+      def [](name)
+        registry[name.to_sym]
+      end
 
-    # Get a list of all color names
-    #
-    # @author {https://aaronmallen.me Aaron Allen}
-    # @since 0.3.1
-    #
-    # @api private
-    #
-    # @return [Array<Symbol>] the color names
-    def self.names
-      (ANSI.keys + CSS.keys + XTERM.keys).uniq.sort
+      # Get a list of all color names
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since 0.3.1
+      #
+      # @api private
+      #
+      # @return [Array<Symbol>] the color names
+      def names
+        @names ||= registry.keys.uniq.sort
+      end
+
+      # Register a named color with an RGB or Hexadecimal value
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @param name [String, Symbol] the name of the color being registered
+      # @param rgb_or_hex [Array<Integer>, String] the RGB or Hexadecimal value of the color
+      #
+      # @return [Boolean] `true` if the color was registered
+      # @rbs (String | Symbol name, Array[Integer] | String rgb_or_hex) -> void
+      def register(name, rgb_or_hex)
+        rgb = Conversion::RGB.resolve(rgb_or_hex)
+        key = name.to_s.downcase.to_sym
+        registry[key] = rgb
+        @names = nil
+        true
+      end
+
+      private
+
+      # The Sai named colors registry
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @return [Hash{Symbol => Array<Integer>}] the named colors registry
+      def registry
+        thread_lock.synchronize do
+          @registry ||= CSS.merge(XTERM).merge(ANSI)
+        end
+      end
+
+      # A Mutex for thread safety
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @return [Mutex] the thread lock
+      # @rbs () -> Mutex
+      def thread_lock
+        @thread_lock ||= Mutex.new
+      end
     end
   end
 end

--- a/lib/sai/named_colors.rb
+++ b/lib/sai/named_colors.rb
@@ -449,14 +449,47 @@ module Sai
       # @return [Boolean] `true` if the color was registered
       # @rbs (String | Symbol name, Array[Integer] | String rgb_or_hex) -> void
       def register(name, rgb_or_hex)
-        rgb = Conversion::RGB.resolve(rgb_or_hex)
         key = name.to_s.downcase.to_sym
-        registry[key] = rgb
-        @names = nil
+        provision_color(key, rgb_or_hex)
+        install_color(key)
         true
       end
 
       private
+
+      # Install the color methods onto {Sai} and {Sai::Decorator}
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @param name [Symbol] the name of the color to install
+      #
+      # @return [void]
+      # @rbs (Symbol name) -> void
+      def install_color(name)
+        Sai::Decorator::NamedColors.install(name)
+        Sai::Decorator::Delegation.install(Sai)
+      end
+
+      # Provision a color for the registry
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @param name [Symbol] the name of the color to register
+      # @param rgb_or_hex [Array<Integer>, String] the RGB or Hexadecimal value of the color
+      #
+      # @return [void]
+      # @rbs (Symbol name, Array[Integer] | String rgb_or_hex) -> void
+      def provision_color(name, rgb_or_hex)
+        rgb = Conversion::RGB.resolve(rgb_or_hex)
+        registry[name] = rgb
+        @names = nil
+      end
 
       # The Sai named colors registry
       #

--- a/sig/sai.rbs
+++ b/sig/sai.rbs
@@ -1574,6 +1574,26 @@ module Sai
   # @rbs () -> singleton(ModeSelector)
   def self.mode: () -> singleton(ModeSelector)
 
+  # Register a custom name and color
+  #
+  # @author {https://aaronmallen.me Aaron Allen}
+  # @since unreleased
+  #
+  # @api public
+  #
+  # @example Register a color
+  #   Sai.register(:my_color, '#CF4C5F')
+  #   Sai.register(:my_color, [207, 76, 95])
+  #
+  #   Sai.my_color.decorate('Hello, world!').to_s #=> "\e[38;2;207;76;95mHello, world!\e[0m"
+  #
+  # @param name [String, Symbol] the name of the color to register
+  # @param rgb_or_hex [Array<Integer>, String] the RGB values or hex code to register
+  #
+  # @return [void]
+  # @rbs (String | Symbol name, Array[Integer] | String rgb_or_hex) -> void
+  def self.register: (String | Symbol name, Array[Integer] | String rgb_or_hex) -> void
+
   # Sequence a string with ANSI escape codes
   #
   # @author {https://aaronmallen.me Aaron Allen}

--- a/sig/sai/decorator/named_colors.rbs
+++ b/sig/sai/decorator/named_colors.rbs
@@ -1471,6 +1471,19 @@ module Sai
 
       def yellow_system: () -> Decorator
 
+      # Install a color method on the {Decorator} class
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @param color_name [Symbol] the name of the color to install
+      #
+      # @return [void]
+      # @rbs (Symbol color_name) -> void
+      def self.install: (Symbol color_name) -> void
+
       private
 
       # Apply a named color to the specified style type

--- a/sig/sai/named_colors.rbs
+++ b/sig/sai/named_colors.rbs
@@ -61,5 +61,40 @@ module Sai
     #
     # @return [Array<Symbol>] the color names
     def self.names: () -> untyped
+
+    # Register a named color with an RGB or Hexadecimal value
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api private
+    #
+    # @param name [String, Symbol] the name of the color being registered
+    # @param rgb_or_hex [Array<Integer>, String] the RGB or Hexadecimal value of the color
+    #
+    # @return [Boolean] `true` if the color was registered
+    # @rbs (String | Symbol name, Array[Integer] | String rgb_or_hex) -> void
+    def self.register: (String | Symbol name, Array[Integer] | String rgb_or_hex) -> void
+
+    # The Sai named colors registry
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api private
+    #
+    # @return [Hash{Symbol => Array<Integer>}] the named colors registry
+    private def self.registry: () -> untyped
+
+    # A Mutex for thread safety
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api private
+    #
+    # @return [Mutex] the thread lock
+    # @rbs () -> Mutex
+    private def self.thread_lock: () -> Mutex
   end
 end

--- a/sig/sai/named_colors.rbs
+++ b/sig/sai/named_colors.rbs
@@ -76,6 +76,33 @@ module Sai
     # @rbs (String | Symbol name, Array[Integer] | String rgb_or_hex) -> void
     def self.register: (String | Symbol name, Array[Integer] | String rgb_or_hex) -> void
 
+    # Install the color methods onto {Sai} and {Sai::Decorator}
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api private
+    #
+    # @param name [Symbol] the name of the color to install
+    #
+    # @return [void]
+    # @rbs (Symbol name) -> void
+    private def self.install_color: (Symbol name) -> void
+
+    # Provision a color for the registry
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api private
+    #
+    # @param name [Symbol] the name of the color to register
+    # @param rgb_or_hex [Array<Integer>, String] the RGB or Hexadecimal value of the color
+    #
+    # @return [void]
+    # @rbs (Symbol name, Array[Integer] | String rgb_or_hex) -> void
+    private def self.provision_color: (Symbol name, Array[Integer] | String rgb_or_hex) -> void
+
     # The Sai named colors registry
     #
     # @author {https://aaronmallen.me Aaron Allen}

--- a/spec/sai/decorator/named_colors_spec.rb
+++ b/spec/sai/decorator/named_colors_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Sai::Decorator::NamedColors do
+  describe '.install' do
+    subject(:install) { described_class.install(color_name) }
+
+    let(:color_name) { :test_color }
+    let(:color) { :test_color }
+    let(:decorator) { Sai::Decorator.new }
+    let(:background) { :background }
+    let(:foreground) { :foreground }
+
+    before do
+      Sai::NamedColors.register(color_name, [255, 0, 0])
+    end
+
+    after do
+      # Clean up test methods to avoid polluting other specs
+      Sai::Decorator.undef_method(color_name) if Sai::Decorator.method_defined?(color_name)
+      Sai::Decorator.undef_method(:"on_#{color_name}") if Sai::Decorator.method_defined?(:"on_#{color_name}")
+    end
+
+    context 'when the methods do not exist' do
+      it 'is expected to add a foreground color method' do
+        install
+        allow(decorator).to receive(:apply_named_color)
+        decorator.public_send(color_name)
+
+        expect(decorator).to have_received(:apply_named_color).with(:foreground, color)
+      end
+
+      it 'is expected to add a background color method' do
+        install
+        allow(decorator).to receive(:apply_named_color)
+        decorator.public_send(:"on_#{color_name}")
+
+        expect(decorator).to have_received(:apply_named_color).with(:background, color)
+      end
+    end
+
+    context 'when the methods already exist' do
+      before do
+        install
+      end
+
+      it 'is expected to redefine the foreground color method' do
+        install
+        allow(decorator).to receive(:apply_named_color)
+        decorator.public_send(color_name)
+
+        expect(decorator).to have_received(:apply_named_color).with(:foreground, color)
+      end
+
+      it 'is expected to redefine the background color method' do
+        install
+        allow(decorator).to receive(:apply_named_color)
+        decorator.public_send(:"on_#{color_name}")
+
+        expect(decorator).to have_received(:apply_named_color).with(:background, color)
+      end
+    end
+  end
+end

--- a/spec/sai/named_colors_spec.rb
+++ b/spec/sai/named_colors_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Sai::NamedColors do
       :@registry,
       described_class::CSS.merge(described_class::XTERM).merge(described_class::ANSI)
     )
+    described_class.names.each { |name| Sai::Decorator::NamedColors.install(name) }
     described_class.instance_variable_set(:@names, nil)
   end
 
@@ -73,6 +74,13 @@ RSpec.describe Sai::NamedColors do
 
     let(:name) { :test_color }
     let(:value) { [100, 100, 100] }
+    let(:decorator) { Sai::Decorator.new }
+
+    after do
+      # Clean up test methods
+      Sai::Decorator.undef_method(name) if Sai::Decorator.method_defined?(name)
+      Sai::Decorator.undef_method(:"on_#{name}") if Sai::Decorator.method_defined?(:"on_#{name}")
+    end
 
     it 'is expected to register a new color' do
       register
@@ -84,13 +92,27 @@ RSpec.describe Sai::NamedColors do
       expect(described_class.names).to include(name)
     end
 
+    it 'is expected to install color methods on Decorator' do
+      register
+      expect(decorator).to respond_to(name).and(respond_to(:"on_#{name}"))
+    end
+
     context 'when registering multiple colors concurrently' do
+      after do
+        # Clean up concurrent test methods
+        50.times do |i|
+          color_name = :"color_#{i}"
+          Sai::Decorator.undef_method(color_name) if Sai::Decorator.method_defined?(color_name)
+          Sai::Decorator.undef_method(:"on_#{color_name}") if Sai::Decorator.method_defined?(:"on_#{color_name}")
+        end
+      end
+
       it 'is expected to handle concurrent registration safely' do
         colors = Array.new(50) { |i| [:"color_#{i}", [i, i, i]] }
 
         threads = colors.map do |color_name, color_value|
           Thread.new do
-            sleep(rand(0.001..0.005)) # Add some randomness to thread timing
+            sleep(rand(0.001..0.005))
             described_class.register(color_name, color_value)
           end
         end
@@ -99,7 +121,9 @@ RSpec.describe Sai::NamedColors do
 
         registered_colors = colors.all? do |color_name, color_value|
           described_class[color_name] == color_value &&
-            described_class.names.include?(color_name)
+            described_class.names.include?(color_name) &&
+            decorator.respond_to?(color_name) &&
+            decorator.respond_to?(:"on_#{color_name}")
         end
 
         expect(registered_colors).to be true
@@ -119,6 +143,13 @@ RSpec.describe Sai::NamedColors do
         original_names = described_class.names
         register
         expect(described_class.names.length).to eq(original_names.length)
+      end
+
+      it 'is expected to update the existing color methods' do
+        register
+        expect(decorator.with_mode(Sai.mode.true_color).send(name).decorate('test').to_s).to(
+          eq("\e[38;2;255;0;0mtest\e[0m")
+        )
       end
     end
   end

--- a/spec/sai/named_colors_spec.rb
+++ b/spec/sai/named_colors_spec.rb
@@ -3,6 +3,19 @@
 require 'spec_helper'
 
 RSpec.describe Sai::NamedColors do
+  before do
+    described_class.instance_variable_set(:@registry, nil)
+    described_class.instance_variable_set(:@names, nil)
+  end
+
+  after do
+    described_class.instance_variable_set(
+      :@registry,
+      described_class::CSS.merge(described_class::XTERM).merge(described_class::ANSI)
+    )
+    described_class.instance_variable_set(:@names, nil)
+  end
+
   describe '.[]' do
     subject(:fetch) { described_class[name] }
 
@@ -46,6 +59,67 @@ RSpec.describe Sai::NamedColors do
       expect(names).to eq(
         (described_class::ANSI.keys + described_class::XTERM.keys + described_class::CSS.keys).uniq.sort
       )
+    end
+
+    it 'is expected to memoize the result' do
+      first_call = described_class.names.object_id
+      second_call = described_class.names.object_id
+      expect(first_call).to eq(second_call)
+    end
+  end
+
+  describe '.register' do
+    subject(:register) { described_class.register(name, value) }
+
+    let(:name) { :test_color }
+    let(:value) { [100, 100, 100] }
+
+    it 'is expected to register a new color' do
+      register
+      expect(described_class[name]).to eq(value)
+    end
+
+    it 'is expected to add the color name to names list' do
+      register
+      expect(described_class.names).to include(name)
+    end
+
+    context 'when registering multiple colors concurrently' do
+      it 'is expected to handle concurrent registration safely' do
+        colors = Array.new(50) { |i| [:"color_#{i}", [i, i, i]] }
+
+        threads = colors.map do |color_name, color_value|
+          Thread.new do
+            sleep(rand(0.001..0.005)) # Add some randomness to thread timing
+            described_class.register(color_name, color_value)
+          end
+        end
+
+        threads.each(&:join)
+
+        registered_colors = colors.all? do |color_name, color_value|
+          described_class[color_name] == color_value &&
+            described_class.names.include?(color_name)
+        end
+
+        expect(registered_colors).to be true
+      end
+    end
+
+    context 'when overriding an existing color' do
+      let(:name) { :red }
+      let(:value) { [255, 0, 0] }
+
+      it 'is expected to override the existing color' do
+        register
+        expect(described_class[name]).to eq(value)
+      end
+
+      it 'is expected to not duplicate the name in the names list' do
+        original_names = described_class.names
+        register
+        expect(described_class.names.length).to eq(original_names.length)
+      end
     end
   end
 end

--- a/spec/sai_spec.rb
+++ b/spec/sai_spec.rb
@@ -11,6 +11,23 @@ RSpec.describe Sai do
     it { is_expected.to eq(Sai::ModeSelector) }
   end
 
+  describe '.register' do
+    subject(:register) { described_class.register(color_name, color_value) }
+
+    before do
+      allow(Sai::NamedColors).to receive(:register)
+    end
+
+    let(:color_name) { :test }
+    let(:color_value) { '#FF0000' }
+
+    it 'is expected to register the color' do
+      register
+
+      expect(Sai::NamedColors).to have_received(:register).with(color_name, color_value)
+    end
+  end
+
   describe '.sequence' do
     subject(:sequence) { described_class.sequence(text) }
 


### PR DESCRIPTION
This introduces the ability to register custom named colors using the `Sai.register` method. These colors are automatically made available as methods on both the `Sai` module and the `Sai::Decorator` class.

## Key Changes

* Custom Color Registration: Users can define named colors via `Sai.register` using either hex codes or RGB arrays.
* Dynamic Method Injection: Registered colors become accessible as methods on `Sai` and `Sai::Decorator`.

## Example Usage

```ruby
Sai.register(:my_color, '#CF4C5F')

# alternatively
Sai.register(:my_color, [207, 76, 95])

Sai.my_color.decorate('Hello, world!')
```

## Motivation

This change sets the stage for offloading the 363 built-in named colors currently bundled with Sai into a separate extension gem. This modular approach will allow users to opt in to only the colors they need, reducing memory overhead and improving performance by avoiding the unnecessary loading of unused colors.

> [!NOTE]
> Users relying on the existing built-in named colors will need to install the forthcoming extension gem to retain the same functionality.