### PR TITLE
Add conversion result caching to improve gradient and rainbow operation performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog], and this project adheres to [Break Ve
 
 * [#19](https://github.com/aaronmallen/sai/pull/19) - Add short hex color support by
   [@aaronmallen](https://github.com/aaronmallen)
+* [#21](https://github.com/aaronmallen/sai/pull/21) - Add conversion result caching to improve gradient and rainbow
+  operation performance by [@aaronmallen](https://github.com/aaronmallen)
 
 ## [0.4.0] - 2025-01-23
 

--- a/lib/sai.rb
+++ b/lib/sai.rb
@@ -3,6 +3,7 @@
 require 'sai/ansi'
 require 'sai/ansi/sequence_processor'
 require 'sai/ansi/sequenced_string'
+require 'sai/conversion/cache'
 require 'sai/conversion/color_sequence'
 require 'sai/conversion/rgb'
 require 'sai/decorator'

--- a/lib/sai/conversion/cache.rb
+++ b/lib/sai/conversion/cache.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Sai
+  module Conversion
+    # The cache module is responsible for storing the results of various calculation results
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api private
+    module Cache
+      class << self
+        # Fetch a value from the cache
+        #
+        # @author {https://aaronmallen.me Aaron Allen}
+        # @since unreleased
+        #
+        # @api private
+        #
+        # @param operation_name [String, Symbol] The name of the operation
+        # @param operation_variables [Object] The variables used in the operation
+        # @yield The block to execute if the value is not found in the cache
+        # @yieldreturn [Object] The result of the operation
+        #
+        # @return [Object] The result of the operation
+        # @rbs (String | Symbol operation_name, untyped operation_variables) ?{ (?) -> untyped } -> untyped
+        def fetch(operation_name, operation_variables, &)
+          lookup[operation_name] ||= {}
+          lookup[operation_name][operation_variables] ||= yield
+        end
+
+        private
+
+        # The cache lookup table where results are stored
+        #
+        # @author {https://aaronmallen.me Aaron Allen}
+        # @since unreleased
+        #
+        # @api private
+        #
+        # @return [Hash{String => Object}]
+        def lookup
+          @lookup ||= {}
+        end
+      end
+    end
+  end
+end

--- a/lib/sai/conversion/rgb/color_classifier.rb
+++ b/lib/sai/conversion/rgb/color_classifier.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'sai/conversion/cache'
+
 module Sai
   module Conversion
     module RGB
@@ -25,12 +27,14 @@ module Sai
           # @return [Symbol] the closest ANSI color name
           # @rbs (Float red, Float green, Float blue) -> Symbol
           def closest_ansi_color(red, green, blue)
-            return :black if dark?(red, green, blue)
-            return :white if grayscale?(red, green, blue)
-            return primary_color(red, green, blue) if primary?(red, green, blue)
-            return secondary_color(red, green, blue) if secondary?(red, green, blue)
+            Cache.fetch(:classifier_closest_ansi_color, [red, green, blue]) do
+              return :black if dark?(red, green, blue)
+              return :white if grayscale?(red, green, blue)
+              return primary_color(red, green, blue) if primary?(red, green, blue)
+              return secondary_color(red, green, blue) if secondary?(red, green, blue)
 
-            :white
+              :white
+            end
           end
 
           # Determine if a color is dark
@@ -47,7 +51,9 @@ module Sai
           # @return [Boolean] true if color is dark
           # @rbs (Float red, Float green, Float blue) -> bool
           def dark?(red, green, blue)
-            [red, green, blue].max < 0.3
+            Cache.fetch(:classifier_dark_predicate, [red, green, blue]) do
+              [red, green, blue].max < 0.3
+            end
           end
 
           # Determine if a color is grayscale
@@ -64,7 +70,9 @@ module Sai
           # @return [Boolean] true if color is grayscale
           # @rbs (Float red, Float green, Float blue) -> bool
           def grayscale?(red, green, blue)
-            red == green && green == blue
+            Cache.fetch(:classifier_grayscale_predicate, [red, green, blue]) do
+              red == green && green == blue
+            end
           end
 
           # Determine if RGB values represent a primary color
@@ -81,9 +89,11 @@ module Sai
           # @return [Boolean] true if color is primary
           # @rbs (Float red, Float green, Float blue) -> bool
           def primary?(red, green, blue)
-            max = [red, green, blue].max
-            mid = [red, green, blue].sort[1]
-            (max - mid) > 0.3
+            Cache.fetch(:classifier_primary_predicate, [red, green, blue]) do
+              max = [red, green, blue].max
+              mid = [red, green, blue].sort[1]
+              (max - mid) > 0.3
+            end
           end
 
           # Get the closest primary color
@@ -100,11 +110,13 @@ module Sai
           # @return [Symbol] the primary color name
           # @rbs (Float red, Float green, Float blue) -> Symbol
           def primary_color(red, green, blue)
-            max = [red, green, blue].max
-            case max
-            when red then :red
-            when green then :green
-            else :blue
+            Cache.fetch(:classifier_primary_color, [red, green, blue]) do
+              max = [red, green, blue].max
+              case max
+              when red then :red
+              when green then :green
+              else :blue
+              end
             end
           end
 
@@ -122,11 +134,13 @@ module Sai
           # @return [Boolean] true if color is secondary
           # @rbs (Float red, Float green, Float blue) -> bool
           def secondary?(red, green, blue)
-            return true if yellow?(red, green, blue)
-            return true if magenta?(red, green, blue)
-            return true if cyan?(red, green, blue)
+            Cache.fetch(:classifier_secondary_predicate, [red, green, blue]) do
+              return true if yellow?(red, green, blue)
+              return true if magenta?(red, green, blue)
+              return true if cyan?(red, green, blue)
 
-            false
+              false
+            end
           end
 
           # Get the closest secondary color
@@ -143,11 +157,13 @@ module Sai
           # @return [Symbol] the secondary color name
           # @rbs (Float red, Float green, Float blue) -> Symbol
           def secondary_color(red, green, blue)
-            return :yellow if yellow?(red, green, blue)
-            return :magenta if magenta?(red, green, blue)
-            return :cyan if cyan?(red, green, blue)
+            Cache.fetch(:classifier_secondary_color, [red, green, blue]) do
+              return :yellow if yellow?(red, green, blue)
+              return :magenta if magenta?(red, green, blue)
+              return :cyan if cyan?(red, green, blue)
 
-            :white
+              :white
+            end
           end
 
           private

--- a/lib/sai/conversion/rgb/color_indexer.rb
+++ b/lib/sai/conversion/rgb/color_indexer.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'sai/conversion/cache'
+
 module Sai
   module Conversion
     module RGB
@@ -23,8 +25,10 @@ module Sai
           # @return [Integer] the color cube index
           # @rbs (Array[Integer] rgb) -> Integer
           def color_cube(rgb)
-            r, g, b = rgb.map { |c| ((c / 255.0) * 5).round } #: [Integer, Integer, Integer]
-            16 + (r * 36) + (g * 6) + b
+            Cache.fetch(:indexer_color_cube, rgb) do
+              r, g, b = rgb.map { |c| ((c / 255.0) * 5).round } #: [Integer, Integer, Integer]
+              16 + (r * 36) + (g * 6) + b
+            end
           end
 
           # Convert RGB values to grayscale index
@@ -39,7 +43,9 @@ module Sai
           # @return [Integer] the grayscale index
           # @rbs (Array[Integer] rgb) -> Integer
           def grayscale(rgb)
-            232 + ((rgb[0] / 255.0) * 23).round
+            Cache.fetch(:indexer_grayscale, rgb) do
+              232 + ((rgb[0] / 255.0) * 23).round
+            end
           end
         end
       end

--- a/sig/sai/conversion/cache.rbs
+++ b/sig/sai/conversion/cache.rbs
@@ -1,0 +1,39 @@
+# Generated from lib/sai/conversion/cache.rb with RBS::Inline
+
+module Sai
+  module Conversion
+    # The cache module is responsible for storing the results of various calculation results
+    #
+    # @author {https://aaronmallen.me Aaron Allen}
+    # @since unreleased
+    #
+    # @api private
+    module Cache
+      # Fetch a value from the cache
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @param operation_name [String, Symbol] The name of the operation
+      # @param operation_variables [Object] The variables used in the operation
+      # @yield The block to execute if the value is not found in the cache
+      # @yieldreturn [Object] The result of the operation
+      #
+      # @return [Object] The result of the operation
+      # @rbs (String | Symbol operation_name, untyped operation_variables) ?{ (?) -> untyped } -> untyped
+      def self.fetch: (String | Symbol operation_name, untyped operation_variables) ?{ (?) -> untyped } -> untyped
+
+      # The cache lookup table where results are stored
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @return [Hash{String => Object}]
+      private def self.lookup: () -> untyped
+    end
+  end
+end

--- a/spec/sai/conversion/cache_spec.rb
+++ b/spec/sai/conversion/cache_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# frozen_string_literal: true
+
+RSpec.describe Sai::Conversion::Cache do
+  describe '.fetch' do
+    subject(:fetch_result) { described_class.fetch(operation_name, operation_variables, &block) }
+
+    let(:operation_name) { :test_operation }
+    let(:operation_variables) { [1, 2, 3] }
+    let(:result) { [4, 5, 6] }
+    let(:block) { -> { result } }
+
+    it 'is expected to return the result of the block' do
+      expect(fetch_result).to eq(result)
+    end
+
+    it 'is expected to cache the result' do
+      first_result = described_class.fetch(operation_name, operation_variables, &block)
+      second_result = described_class.fetch(operation_name, operation_variables, &block)
+
+      expect(second_result).to equal(first_result)
+    end
+
+    context 'when using different operation names' do
+      let(:other_operation) { :other_operation }
+
+      it 'is expected to cache results separately' do
+        first_result = described_class.fetch(operation_name, operation_variables, &block)
+        other_result = described_class.fetch(other_operation, operation_variables, &block)
+
+        expect(other_result).not_to equal(first_result)
+      end
+    end
+
+    context 'when using different operation variables' do
+      let(:other_variables) { [7, 8, 9] }
+
+      it 'is expected to cache results separately' do
+        first_result = described_class.fetch(operation_name, operation_variables, &block)
+        other_result = described_class.fetch(operation_name, other_variables, &block)
+
+        expect(other_result).not_to equal(first_result)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds a simple memoization cache to store calculation results in the Conversion namespace. The cache is particularly effective for operations that perform repeated color space calculations.

## Performance improvements

* Gradient operations: +22% (11,386 → 13,893 IPS)
* Rainbow operations: +12% (12,316 → 13,759 IPS)
* Multiple styles: +4.5% (75,571 → 78,983 IPS)
* Hex color: +9.6% (97,213 → 106,542 IPS)
* Named color: +5.2% (101,716 → 107,053 IPS)

The implementation uses a minimal lookup hash to cache operation results, providing significant performance gains with negligible memory overhead. Most operations show slightly reduced object allocation and improved object retention patterns.

## Changes

* Add Cache module for memoizing calculation results
* Add specs for Cache module functionality
* No breaking changes or API modifications