### PR TITLE
Add `tty?` method to check if stdout is a TTY

### DIFF
--- a/lib/sai/terminal/capabilities.rb
+++ b/lib/sai/terminal/capabilities.rb
@@ -88,7 +88,7 @@ module Sai
         # @return [Boolean] `true` if the NO_COLOR environment variable is set, otherwise `false`
         # @rbs () -> bool
         def no_color?
-          !ENV.fetch('NO_COLOR', '').empty? || !$stdout.tty?
+          !ENV.fetch('NO_COLOR', '').empty? || !tty?
         end
 
         # Check for true color (24-bit) support
@@ -114,6 +114,19 @@ module Sai
           end
 
           false
+        end
+
+        # Check if stdout is a TTY
+        #
+        # @author {https://aaronmallen.me Aaron Allen}
+        # @since unreleased
+        #
+        # @api private
+        #
+        # @return [Boolean] `true` if stdout is a TTY, otherwise `false`
+        # @rbs () -> bool
+        def tty?
+          @tty ||= $stdout.tty?
         end
       end
     end

--- a/sig/sai/terminal/capabilities.rbs
+++ b/sig/sai/terminal/capabilities.rbs
@@ -76,6 +76,17 @@ module Sai
       # @return [Boolean] `true` if the terminal supports true color, otherwise `false`
       # @rbs () -> bool
       private def self.true_color?: () -> bool
+
+      # Check if stdout is a TTY
+      #
+      # @author {https://aaronmallen.me Aaron Allen}
+      # @since unreleased
+      #
+      # @api private
+      #
+      # @return [Boolean] `true` if stdout is a TTY, otherwise `false`
+      # @rbs () -> bool
+      private def self.tty?: () -> bool
     end
   end
 end


### PR DESCRIPTION
Introduce a `tty?` method to encapsulate the logic for checking if stdout is a TTY. This provides a small performance increase as we appear to be spending a surprising amount of time asking IO if it's tty.