### PR TITLE
Refactor `Sai::Terminal::Capabilities`

### DIFF
--- a/sig/sai/terminal/capabilities.rbs
+++ b/sig/sai/terminal/capabilities.rbs
@@ -27,9 +27,9 @@ module Sai
       #
       # @api private
       #
-      # @return [Boolean] `true` if the terminal supports 256 colors, otherwise `false`
-      # @rbs () -> bool
-      private def self.advanced?: () -> bool
+      # @return [Integer, nil] the {ColorMode} or `nil` if not supported
+      # @rbs () -> Integer?
+      private def self.advanced: () -> Integer?
 
       # Check for ANSI color support
       #
@@ -38,9 +38,9 @@ module Sai
       #
       # @api private
       #
-      # @return [Boolean] `true` if the terminal supports basic ANSI colors, otherwise `false`
-      # @rbs () -> bool
-      private def self.ansi?: () -> bool
+      # @return [Integer, nil] the {ColorMode} or `nil` if not supported
+      # @rbs () -> Integer?
+      private def self.ansi: () -> Integer?
 
       # Check for basic color support
       #
@@ -49,9 +49,9 @@ module Sai
       #
       # @api private
       #
-      # @return [Boolean] `true` if the terminal supports basic colors, otherwise `false`
-      # @rbs () -> bool
-      private def self.basic?: () -> bool
+      # @return [Integer, nil] the {ColorMode} or `nil` if not supported
+      # @rbs () -> Integer?
+      private def self.basic: () -> Integer?
 
       # Check for NO_COLOR environment variable
       #
@@ -62,9 +62,9 @@ module Sai
       #
       # @see https://no-color.org
       #
-      # @return [Boolean] `true` if the NO_COLOR environment variable is set, otherwise `false`
-      # @rbs () -> bool
-      private def self.no_color?: () -> bool
+      # @return [Integer, nil] the {ColorMode} or `nil` if not supported
+      # @rbs () -> Integer?
+      private def self.no_color: () -> Integer?
 
       # Check for true color (24-bit) support
       #
@@ -73,20 +73,9 @@ module Sai
       #
       # @api private
       #
-      # @return [Boolean] `true` if the terminal supports true color, otherwise `false`
-      # @rbs () -> bool
-      private def self.true_color?: () -> bool
-
-      # Check if stdout is a TTY
-      #
-      # @author {https://aaronmallen.me Aaron Allen}
-      # @since unreleased
-      #
-      # @api private
-      #
-      # @return [Boolean] `true` if stdout is a TTY, otherwise `false`
-      # @rbs () -> bool
-      private def self.tty?: () -> bool
+      # @return [Integer, nil] the {ColorMode} or `nil` if not supported
+      # @rbs () -> Integer?
+      private def self.true_color: () -> Integer?
     end
   end
 end

--- a/spec/sai/terminal/capabilities_spec.rb
+++ b/spec/sai/terminal/capabilities_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe Sai::Terminal::Capabilities do
   describe '.detect_color_support' do
     subject(:detect_color_support) { described_class.detect_color_support }
 
+    before { described_class.instance_variable_set(:@detect_color_support, nil) }
+
     context 'when NO_COLOR environment variable is set' do
       before do
         stub_const('ENV', { 'NO_COLOR' => 'true' })


### PR DESCRIPTION
This caches the result of `Sai::Terminal::Capabilities#detect_color_support` for a very small increase in performance. It is almost impossible for this value to change within the life cycle of the operation that loaded it in.